### PR TITLE
Threshold codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # allow a small drop due to flaky tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ coverage:
       default:
         target: auto
         # allow a small drop due to flaky tests
+        threshold: 0.5%


### PR DESCRIPTION
For example, #231 is labelled as failing, although nothing in the python has changed https://app.codecov.io/gh/quantumjot/btrack/pull/231. This change means that we can allow a small drop. 0.5% is an arbitrary choice, so if any strong views let me know.