### PR TITLE
Bump `pre-commit` and add `clang-format` and run over all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/charliermarsh/ruff-pre-commit
-      rev: v0.0.254
+      rev: v0.0.257
       hooks:
         - id: ruff
     - repo: https://github.com/Lucas-C/pre-commit-hooks
@@ -9,7 +9,7 @@ repos:
         - id: remove-tabs
           exclude: Makefile|docs/Makefile|\.bat$
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.2.0
+      rev: v4.4.0
       hooks:
           - id: check-case-conflict
           - id: check-docstring-first
@@ -23,10 +23,14 @@ repos:
           - id: trailing-whitespace
             args: [--markdown-linebreak-ext=md]
     - repo: https://github.com/psf/black
-      rev: 22.3.0
+      rev: 23.1.0
       hooks:
           - id: black
     - repo: https://github.com/pappasam/toml-sort
-      rev: v0.22.4
+      rev: v0.23.0
       hooks:
         - id: toml-sort-fix
+    - repo: https://github.com/pre-commit/mirrors-clang-format
+      rev: v15.0.7
+      hooks:
+      - id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,4 @@ repos:
       rev: v15.0.7
       hooks:
       - id: clang-format
+        types_or: [c++, c, cuda]

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -163,7 +163,6 @@ class PyTrackObject(ctypes.Structure):
         fields = {k: kt for k, kt in PyTrackObject._fields_}
         attr = [k for k in fields if k in properties]
         for key in attr:
-
             new_data = properties[key]
 
             # fix for implicit type conversion
@@ -363,7 +362,6 @@ class Tracklet:
         children: Optional[List[int]] = None,
         fate: constants.Fates = constants.Fates.UNDEFINED,
     ):
-
         assert all([isinstance(o, PyTrackObject) for o in data])
 
         self.ID = ID

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -160,7 +160,7 @@ class BayesianTracker:
 
     def configure_from_file(self, filename: os.PathLike) -> None:
         """Configure the tracker from a configuration file. See `configure`."""
-        warnings.warn(
+        warnings.warn(  # noqa: B028
             "This function will be deprecated. Use `.configure()` instead.",
             DeprecationWarning,
         )

--- a/btrack/dataio.py
+++ b/btrack/dataio.py
@@ -1,12 +1,9 @@
 import warnings
 
-warnings.warn(
+warnings.warn(  # noqa: B028
     "`btrack.dataio` has been deprecated. Please use `btrack.io` subpackage "
     "instead.",
     # DeprecationWarning,
 )
 
 from .io import HDF5FileHandler  # noqa: F401,E402
-
-if __name__ == "__main__":
-    pass

--- a/btrack/include/bayes.h
+++ b/btrack/include/bayes.h
@@ -27,6 +27,6 @@ std::tuple<double, double> safe_bayesian_update(double prior_assign,
                                                 double prob_not_assign);
 
 double safe_bayesian_update_simple(double prior, double likelihood);
-}
+} // namespace BayesianUpdateFunctions
 
 #endif

--- a/btrack/include/belief.h
+++ b/btrack/include/belief.h
@@ -22,12 +22,9 @@
 #include <cuda_runtime.h>
 
 // update the belief matrix using a CUDA kernel
-void cost_CUDA( float* belief_matrix,
-                const float* new_positions,
-                const float* predicted_positions,
-                const unsigned int N,
-                const unsigned int T,
-                const float prob_not_assign,
-                const float accuracy );
+void cost_CUDA(float *belief_matrix, const float *new_positions,
+               const float *predicted_positions, const unsigned int N,
+               const unsigned int T, const float prob_not_assign,
+               const float accuracy);
 
 #endif

--- a/btrack/include/defs.h
+++ b/btrack/include/defs.h
@@ -45,7 +45,6 @@
 #define STRICT_TRACKLET_LINKING 0
 #endif
 
-
 // store some information about the compilation
 static unsigned int v_major = VERSION_MAJOR;
 static unsigned int v_minor = VERSION_MINOR;
@@ -145,22 +144,22 @@ const double kRootTwoPi = std::sqrt(2.0 * M_PI);
 #define TYPE_undef 999
 
 enum class HypothesisType : unsigned int {
-    false_positive = 0,
-    init = 1,
-    term = 2,
-    link = 3,
-    branch = 4,
-    apop = 5,
-    merge = 6,
-    extrude = 7,
-    init_border = 10,
-    init_front = 11,
-    init_lazy = 12,
-    term_border = 20,
-    term_back = 21,
-    term_lazy = 22,
-    dead = 666,
-    undefined = 999
+  false_positive = 0,
+  init = 1,
+  term = 2,
+  link = 3,
+  branch = 4,
+  apop = 5,
+  merge = 6,
+  extrude = 7,
+  init_border = 10,
+  init_front = 11,
+  init_lazy = 12,
+  term_border = 20,
+  term_back = 21,
+  term_lazy = 22,
+  dead = 666,
+  undefined = 999
 };
 
 // errors
@@ -177,17 +176,17 @@ enum class HypothesisType : unsigned int {
 #define ERROR_none 910
 
 enum class TrackingError : unsigned int {
-    success = 900,
-    empty_queue = 901,
-    no_tracks = 902,
-    no_useable_frames = 903,
-    track_empty = 904,
-    incorrect_motion_model = 905,
-    max_lost_out_of_range = 906,
-    accuracy_out_of_range = 907,
-    prob_not_assign_out_of_range = 908,
-    not_defined = 909,
-    none = 910
+  success = 900,
+  empty_queue = 901,
+  no_tracks = 902,
+  no_useable_frames = 903,
+  track_empty = 904,
+  incorrect_motion_model = 905,
+  max_lost_out_of_range = 906,
+  accuracy_out_of_range = 907,
+  prob_not_assign_out_of_range = 908,
+  not_defined = 909,
+  none = 910
 };
 
 // possible states of objects
@@ -200,13 +199,13 @@ enum class TrackingError : unsigned int {
 #define STATE_dummy 99
 
 enum class ObjectStateLabel : unsigned int {
-    interphase = 0,
-    prometaphase = 1,
-    metaphase = 2,
-    anaphase = 3,
-    apoptosis = 4,
-    null = 5,
-    dummy = 99
+  interphase = 0,
+  prometaphase = 1,
+  metaphase = 2,
+  anaphase = 3,
+  apoptosis = 4,
+  null = 5,
+  dummy = 99
 };
 
 #define GRAPH_EDGE_link 0

--- a/btrack/include/hyperbin.h
+++ b/btrack/include/hyperbin.h
@@ -29,18 +29,21 @@
 
 // Hash index for use with the hash cube
 struct HashIndex {
-    int x = 0;
-    int y = 0;
-    int z = 0;
-    int n = 0;
+  int x = 0;
+  int y = 0;
+  int z = 0;
+  int n = 0;
 
-    // comparison operator for hash map, strict weak ordering
-    bool operator<(const HashIndex &o) const {
-        if (x != o.x) return x < o.x;
-        if (y != o.y) return y < o.y;
-        if (z != o.z) return z < o.z;
-        return n < o.n;
-    }
+  // comparison operator for hash map, strict weak ordering
+  bool operator<(const HashIndex &o) const {
+    if (x != o.x)
+      return x < o.x;
+    if (y != o.y)
+      return y < o.y;
+    if (z != o.z)
+      return z < o.z;
+    return n < o.n;
+  }
 };
 
 // A 4D hash (hyper) cube object.
@@ -51,57 +54,55 @@ struct HashIndex {
 // functionality
 //
 //
-template <typename T>
-class HashBin {
-   public:
-    // constructors and desctructors
-    HashBin();
-    ~HashBin();
+template <typename T> class HashBin {
+public:
+  // constructors and desctructors
+  HashBin();
+  ~HashBin();
 
-    // set up a hashbin with specific xyz and n sized bins
-    HashBin(const unsigned int bin_xyz, const unsigned int bin_n);
+  // set up a hashbin with specific xyz and n sized bins
+  HashBin(const unsigned int bin_xyz, const unsigned int bin_n);
 
-    // return a 4D index into the hypercube using cartesian coordinates (and
-    // time)
-    HashIndex hash_index(const float x, const float y, const float z,
-                         const float n) const;
+  // return a 4D index into the hypercube using cartesian coordinates (and
+  // time)
+  HashIndex hash_index(const float x, const float y, const float z,
+                       const float n) const;
 
-    // get the contents of a bin
-    std::vector<T> get_contents(const HashIndex a_idx);
+  // get the contents of a bin
+  std::vector<T> get_contents(const HashIndex a_idx);
 
-    // private:
-    //  bin size x,y,z,t
-    float m_bin_size[4] = {0., 0., 0., 0.};
+  // private:
+  //  bin size x,y,z,t
+  float m_bin_size[4] = {0., 0., 0., 0.};
 
-    // a map to the tracks found in a certain bin
-    std::map<HashIndex, std::vector<T>> m_cube;
+  // a map to the tracks found in a certain bin
+  std::map<HashIndex, std::vector<T>> m_cube;
 };
 
 // This should be the parent class of the HypercubeBin and ObjectBin
-template <typename T>
-class BinMap {
-   public:
-    BinMap();
-    BinMap(const unsigned int bin_xyz, const unsigned int bin_n) = 0;
-    ~BinMap();
+template <typename T> class BinMap {
+public:
+  BinMap();
+  BinMap(const unsigned int bin_xyz, const unsigned int bin_n) = 0;
+  ~BinMap();
 
-    // add a generic object
-    void add_object(T a_obj);
+  // add a generic object
+  void add_object(T a_obj);
 
-    // return a 4D index into the hypercube using an object
-    HashIndex hash_index(TrackObjectPtr a_obj) const {
-        return hash_index(a_obj->x, a_obj->y, a_obj->z, a_obj->t);
-    };
+  // return a 4D index into the hypercube using an object
+  HashIndex hash_index(TrackObjectPtr a_obj) const {
+    return hash_index(a_obj->x, a_obj->y, a_obj->z, a_obj->t);
+  };
 
-    // return a 4D index into the hypercube using cartesian coordinates (and
-    // time)
-    HashIndex hash_index(const float x, const float y, const float z,
-                         const float n) const;
+  // return a 4D index into the hypercube using cartesian coordinates (and
+  // time)
+  HashIndex hash_index(const float x, const float y, const float z,
+                       const float n) const;
 
-   private:
-    //
-   protected:
-    //
+private:
+  //
+protected:
+  //
 };
 
 // A 4D hash (hyper) cube object.
@@ -110,91 +111,91 @@ class BinMap {
 // thus preventing excessive searching over non-local trajectories.
 //
 class HypercubeBin {
-   public:
-    // constructors and destructors
-    HypercubeBin();
-    HypercubeBin(const unsigned int bin_xyz, const unsigned int bin_n);
-    ~HypercubeBin();
+public:
+  // constructors and destructors
+  HypercubeBin();
+  HypercubeBin(const unsigned int bin_xyz, const unsigned int bin_n);
+  ~HypercubeBin();
 
-    // is the hypercube empty?
-    bool empty() const { return m_cube.empty(); };
+  // is the hypercube empty?
+  bool empty() const { return m_cube.empty(); };
 
-    // clear the map
-    void clear() { m_cube.clear(); };
+  // clear the map
+  void clear() { m_cube.clear(); };
 
-    // return a 4D index into the hypercube using the object at the start or
-    // end of an exisiting track
-    HashIndex hash_index(TrackletPtr a_trk, const bool a_start) const;
+  // return a 4D index into the hypercube using the object at the start or
+  // end of an exisiting track
+  HashIndex hash_index(TrackletPtr a_trk, const bool a_start) const;
 
-    // return a 4D index into the hypercube using an object
-    HashIndex hash_index(TrackObjectPtr a_obj) const {
-        return hash_index(a_obj->x, a_obj->y, a_obj->z, a_obj->t);
-    };
+  // return a 4D index into the hypercube using an object
+  HashIndex hash_index(TrackObjectPtr a_obj) const {
+    return hash_index(a_obj->x, a_obj->y, a_obj->z, a_obj->t);
+  };
 
-    // return a 4D index into the hypercube using cartesian coordinates (and
-    // time)
-    HashIndex hash_index(const float x, const float y, const float z,
-                         const float n) const;
+  // return a 4D index into the hypercube using cartesian coordinates (and
+  // time)
+  HashIndex hash_index(const float x, const float y, const float z,
+                       const float n) const;
 
-    // bin sort a track in the hypercube, default behaviour is to add the tracks
-    // so that the bin stores the first object of the track. Use the full
-    // version with the a_start flag (set to false) to store the last known
-    // position of the track during lookup
-    void add_tracklet(TrackletPtr a_trk);
-    void add_tracklet(TrackletPtr a_trk, const bool a_start);
+  // bin sort a track in the hypercube, default behaviour is to add the tracks
+  // so that the bin stores the first object of the track. Use the full
+  // version with the a_start flag (set to false) to store the last known
+  // position of the track during lookup
+  void add_tracklet(TrackletPtr a_trk);
+  void add_tracklet(TrackletPtr a_trk, const bool a_start);
 
-    // return tracks found in a bin
-    std::vector<TrackletPtr> get(TrackletPtr a_trk, const bool a_start);
-    std::vector<TrackletPtr> get(TrackObjectPtr a_obj);
+  // return tracks found in a bin
+  std::vector<TrackletPtr> get(TrackletPtr a_trk, const bool a_start);
+  std::vector<TrackletPtr> get(TrackObjectPtr a_obj);
 
-   private:
-    // bin size x,y,z,t
-    float m_bin_size[4] = {0., 0., 0., 0.};
+private:
+  // bin size x,y,z,t
+  float m_bin_size[4] = {0., 0., 0., 0.};
 
-    // a map to the tracks found in a certain bin
-    std::map<HashIndex, std::vector<TrackletPtr>> m_cube;
+  // a map to the tracks found in a certain bin
+  std::map<HashIndex, std::vector<TrackletPtr>> m_cube;
 };
 
 // a type to maintain the object index, object_ptr pair
 typedef std::pair<TrackObjectPtr, unsigned int> TrackObjectPtr_and_Index;
 
 class ObjectBin {
-   public:
-    // constructors and destructors
-    ObjectBin();
-    ObjectBin(const unsigned int bin_xyz, const unsigned int bin_n);
-    ~ObjectBin();
+public:
+  // constructors and destructors
+  ObjectBin();
+  ObjectBin(const unsigned int bin_xyz, const unsigned int bin_n);
+  ~ObjectBin();
 
-    // return a 4D index into the hypercube using an object
-    HashIndex hash_index(TrackObjectPtr a_obj) const {
-        return hash_index(a_obj->x, a_obj->y, a_obj->z, a_obj->t);
-    };
+  // return a 4D index into the hypercube using an object
+  HashIndex hash_index(TrackObjectPtr a_obj) const {
+    return hash_index(a_obj->x, a_obj->y, a_obj->z, a_obj->t);
+  };
 
-    // return a 4D index into the hypercube using the object at the start or
-    // end of an exisiting track
-    HashIndex hash_index(TrackletPtr a_trk, const bool a_start) const;
+  // return a 4D index into the hypercube using the object at the start or
+  // end of an exisiting track
+  HashIndex hash_index(TrackletPtr a_trk, const bool a_start) const;
 
-    // return a 4D index into the hypercube using cartesian coordinates (and
-    // time)
-    HashIndex hash_index(const float x, const float y, const float z,
-                         const float n) const;
+  // return a 4D index into the hypercube using cartesian coordinates (and
+  // time)
+  HashIndex hash_index(const float x, const float y, const float z,
+                       const float n) const;
 
-    // add an object
-    void add_object(TrackObjectPtr a_obj);
+  // add an object
+  void add_object(TrackObjectPtr a_obj);
 
-    // return tracks found in a bin
-    std::vector<TrackObjectPtr_and_Index> get(TrackletPtr a_trk,
-                                              const bool a_start);
+  // return tracks found in a bin
+  std::vector<TrackObjectPtr_and_Index> get(TrackletPtr a_trk,
+                                            const bool a_start);
 
-   private:
-    // bin size x,y,z,t
-    float m_bin_size[4] = {0., 0., 0., 0.};
+private:
+  // bin size x,y,z,t
+  float m_bin_size[4] = {0., 0., 0., 0.};
 
-    // number of objects
-    unsigned int n_objects = 0;
+  // number of objects
+  unsigned int n_objects = 0;
 
-    // a map to the tracks found in a certain bin
-    std::map<HashIndex, std::vector<TrackObjectPtr_and_Index>> m_cube;
+  // a map to the tracks found in a certain bin
+  std::map<HashIndex, std::vector<TrackObjectPtr_and_Index>> m_cube;
 };
 
 #endif

--- a/btrack/include/hypothesis.h
+++ b/btrack/include/hypothesis.h
@@ -40,74 +40,74 @@ class Hypothesis;
 // Store a hypothesis to return to Python
 // NOTE(arl): the probability is actually the log probability
 extern "C" struct PyHypothesis {
-    unsigned int hypothesis;
-    unsigned int ID;
-    double probability;
-    unsigned int link_ID;
-    unsigned int child_one_ID;
-    unsigned int child_two_ID;
-    unsigned int parent_one_ID;
-    unsigned int parent_two_ID;
+  unsigned int hypothesis;
+  unsigned int ID;
+  double probability;
+  unsigned int link_ID;
+  unsigned int child_one_ID;
+  unsigned int child_two_ID;
+  unsigned int parent_one_ID;
+  unsigned int parent_two_ID;
 
-    PyHypothesis(unsigned int h, unsigned int id) : hypothesis(h), ID(id){};
+  PyHypothesis(unsigned int h, unsigned int id) : hypothesis(h), ID(id){};
 };
 
 // Internal hypothesis class
 class Hypothesis {
-   public:
-    Hypothesis(){};
-    ~Hypothesis(){};
-    Hypothesis(const unsigned int h, const TrackletPtr a_trk)
-        : hypothesis(h), ID(a_trk->ID), trk_ID(a_trk){};
+public:
+  Hypothesis(){};
+  ~Hypothesis(){};
+  Hypothesis(const unsigned int h, const TrackletPtr a_trk)
+      : hypothesis(h), ID(a_trk->ID), trk_ID(a_trk){};
 
-    unsigned int hypothesis = TYPE_undef;
-    unsigned int ID;
-    double probability;
+  unsigned int hypothesis = TYPE_undef;
+  unsigned int ID;
+  double probability;
 
-    // store pointers to the tracks
-    TrackletPtr trk_ID;
+  // store pointers to the tracks
+  TrackletPtr trk_ID;
 
-    // used only for track joining
-    TrackletPtr trk_link_ID;
+  // used only for track joining
+  TrackletPtr trk_link_ID;
 
-    // used for track branching
-    TrackletPtr trk_child_one_ID;
-    TrackletPtr trk_child_two_ID;
+  // used for track branching
+  TrackletPtr trk_child_one_ID;
+  TrackletPtr trk_child_two_ID;
 
-    // used for track merging
-    TrackletPtr trk_parent_one_ID;
-    TrackletPtr trk_parent_two_ID;
+  // used for track merging
+  TrackletPtr trk_parent_one_ID;
+  TrackletPtr trk_parent_two_ID;
 
-    // return a python compatible hypothesis
-    PyHypothesis get_hypothesis() const {
-        assert(this->hypothesis != TYPE_undef);
+  // return a python compatible hypothesis
+  PyHypothesis get_hypothesis() const {
+    assert(this->hypothesis != TYPE_undef);
 
-        PyHypothesis h = PyHypothesis(this->hypothesis, this->trk_ID->ID);
-        h.probability = this->probability;
+    PyHypothesis h = PyHypothesis(this->hypothesis, this->trk_ID->ID);
+    h.probability = this->probability;
 
-        // track joining
-        if (this->hypothesis == TYPE_Plink && trk_link_ID != NULL) {
-            h.link_ID = this->trk_link_ID->ID;
-        };
-
-        // track branching
-        if (this->hypothesis == TYPE_Pdivn && trk_child_one_ID != NULL &&
-            trk_child_two_ID != NULL) {
-            h.child_one_ID = this->trk_child_one_ID->ID;
-            h.child_two_ID = this->trk_child_two_ID->ID;
-        };
-
-        // track merging
-        if (this->hypothesis == TYPE_Pmrge && trk_parent_one_ID != NULL &&
-            trk_parent_two_ID != NULL) {
-            h.parent_one_ID = this->trk_parent_one_ID->ID;
-            h.parent_two_ID = this->trk_parent_two_ID->ID;
-        };
-
-        return h;
+    // track joining
+    if (this->hypothesis == TYPE_Plink && trk_link_ID != NULL) {
+      h.link_ID = this->trk_link_ID->ID;
     };
 
-   private:
+    // track branching
+    if (this->hypothesis == TYPE_Pdivn && trk_child_one_ID != NULL &&
+        trk_child_two_ID != NULL) {
+      h.child_one_ID = this->trk_child_one_ID->ID;
+      h.child_two_ID = this->trk_child_two_ID->ID;
+    };
+
+    // track merging
+    if (this->hypothesis == TYPE_Pmrge && trk_parent_one_ID != NULL &&
+        trk_parent_two_ID != NULL) {
+      h.parent_one_ID = this->trk_parent_one_ID->ID;
+      h.parent_two_ID = this->trk_parent_two_ID->ID;
+    };
+
+    return h;
+  };
+
+private:
 };
 
 // // A 4D hash (hyper) cube object.
@@ -139,20 +139,20 @@ class Hypothesis {
 
 // A structure to store hypothesis generation parameters
 extern "C" struct PyHypothesisParams {
-    double lambda_time;
-    double lambda_dist;
-    double lambda_link;
-    double lambda_branch;
-    double eta;
-    double theta_dist;
-    double theta_time;
-    double dist_thresh;
-    double time_thresh;
-    unsigned int apop_thresh;
-    double segmentation_miss_rate;
-    double apoptosis_rate;
-    bool relax;
-    unsigned int hypotheses_to_generate;
+  double lambda_time;
+  double lambda_dist;
+  double lambda_link;
+  double lambda_branch;
+  double eta;
+  double theta_dist;
+  double theta_time;
+  double dist_thresh;
+  double time_thresh;
+  unsigned int apop_thresh;
+  double segmentation_miss_rate;
+  double apoptosis_rate;
+  bool relax;
+  unsigned int hypotheses_to_generate;
 };
 
 // count the number of apoptosis detections
@@ -191,98 +191,97 @@ double safe_log(double value);
 //   7. P_extrude: a cell extrusion event. A cell is removed from the tissue.
 
 class HypothesisEngine : public UpdateFeatures {
-   public:
-    // constructors and destructors
-    HypothesisEngine();
-    ~HypothesisEngine();
-    HypothesisEngine(const unsigned int a_start_frame,
-                     const unsigned int a_stop_frame,
-                     const PyHypothesisParams& a_params,
-                     TrackManager* a_manager);
+public:
+  // constructors and destructors
+  HypothesisEngine();
+  ~HypothesisEngine();
+  HypothesisEngine(const unsigned int a_start_frame,
+                   const unsigned int a_stop_frame,
+                   const PyHypothesisParams &a_params, TrackManager *a_manager);
 
-    // add a track to the hypothesis engine
-    void add_track(TrackletPtr a_trk);
+  // add a track to the hypothesis engine
+  void add_track(TrackletPtr a_trk);
 
-    // process the trajectories
-    void create();
-    // void log_error(Hypothesis *h);
+  // process the trajectories
+  void create();
+  // void log_error(Hypothesis *h);
 
-    // reset the hypothesis engine
-    void reset();
-    void clear() { reset(); };
+  // reset the hypothesis engine
+  void reset();
+  void clear() { reset(); };
 
-    // return the number of hypotheses
-    size_t size() const { return m_hypotheses.size(); }
+  // return the number of hypotheses
+  size_t size() const { return m_hypotheses.size(); }
 
-    // test whether we need to generate this hypothesis
-    bool hypothesis_allowed(const unsigned int a_hypothesis_type) const;
+  // test whether we need to generate this hypothesis
+  bool hypothesis_allowed(const unsigned int a_hypothesis_type) const;
 
-    // get a hypothesis
-    // TODO(arl): return a reference?
-    const PyHypothesis get_hypothesis(const unsigned int a_ID) const {
-        return m_hypotheses[a_ID].get_hypothesis();
-    }
+  // get a hypothesis
+  // TODO(arl): return a reference?
+  const PyHypothesis get_hypothesis(const unsigned int a_ID) const {
+    return m_hypotheses[a_ID].get_hypothesis();
+  }
 
-    // space to store the hypotheses
-    std::vector<Hypothesis> m_hypotheses;
+  // space to store the hypotheses
+  std::vector<Hypothesis> m_hypotheses;
 
-    // frame size and number of frames
-    // NOTE(arl): technically, this info is already in the imaging volume...
-    unsigned int m_frame_range[2] = {0, 1};
+  // frame size and number of frames
+  // NOTE(arl): technically, this info is already in the imaging volume...
+  unsigned int m_frame_range[2] = {0, 1};
 
-    // space to store the imaging volume when setting up the HashCube
-    ImagingVolume volume;
+  // space to store the imaging volume when setting up the HashCube
+  ImagingVolume volume;
 
-   private:
-    // create hypotheses
-    void hypothesis_false_positive(TrackletPtr a_trk);
-    void hypothesis_init(TrackletPtr a_trk);
-    void hypothesis_term(TrackletPtr a_trk);
-    void hypothesis_dead(TrackletPtr a_trk);
-    void hypothesis_link(TrackletPtr a_trk, TrackletPtr a_trk_lnk);
-    void hypothesis_branch(TrackletPtr a_trk, TrackletPtr a_trk_c0,
-                           TrackletPtr a_trk_c1);
+private:
+  // create hypotheses
+  void hypothesis_false_positive(TrackletPtr a_trk);
+  void hypothesis_init(TrackletPtr a_trk);
+  void hypothesis_term(TrackletPtr a_trk);
+  void hypothesis_dead(TrackletPtr a_trk);
+  void hypothesis_link(TrackletPtr a_trk, TrackletPtr a_trk_lnk);
+  void hypothesis_branch(TrackletPtr a_trk, TrackletPtr a_trk_c0,
+                         TrackletPtr a_trk_c1);
 
-    // calculation of probabilities
-    double P_TP(TrackletPtr a_trk) const;
-    double P_FP(TrackletPtr a_trk) const;
+  // calculation of probabilities
+  double P_TP(TrackletPtr a_trk) const;
+  double P_FP(TrackletPtr a_trk) const;
 
-    double P_init_border(TrackletPtr a_trk) const;
-    double P_init_front(TrackletPtr a_trk) const;
+  double P_init_border(TrackletPtr a_trk) const;
+  double P_init_front(TrackletPtr a_trk) const;
 
-    double P_term_border(TrackletPtr a_trk) const;
-    double P_term_back(TrackletPtr a_trk) const;
+  double P_term_border(TrackletPtr a_trk) const;
+  double P_term_back(TrackletPtr a_trk) const;
 
-    double P_link(TrackletPtr a_trk, TrackletPtr a_trk_link) const;
-    double P_link(TrackletPtr a_trk, TrackletPtr a_trk_link, float d,
-                  float dt) const;
+  double P_link(TrackletPtr a_trk, TrackletPtr a_trk_link) const;
+  double P_link(TrackletPtr a_trk, TrackletPtr a_trk_link, float d,
+                float dt) const;
 
-    double P_branch(TrackletPtr a_trk, TrackletPtr a_trk_c0,
-                    TrackletPtr a_trk_c1) const;
+  double P_branch(TrackletPtr a_trk, TrackletPtr a_trk_c0,
+                  TrackletPtr a_trk_c1) const;
 
-    double P_dead(TrackletPtr a_trk, const unsigned int n_dead) const;
-    double P_dead(TrackletPtr a_trk) const;
+  double P_dead(TrackletPtr a_trk, const unsigned int n_dead) const;
+  double P_dead(TrackletPtr a_trk) const;
 
-    double P_merge(TrackletPtr a_trk_m0, TrackletPtr a_trk_m1,
-                   TrackletPtr a_trk) const;
+  double P_merge(TrackletPtr a_trk_m0, TrackletPtr a_trk_m1,
+                 TrackletPtr a_trk) const;
 
-    double P_extrude(TrackletPtr a_trk) const;
+  double P_extrude(TrackletPtr a_trk) const;
 
-    // calculate the distance of a track from the border of the imaging volume
-    float dist_from_border(TrackletPtr a_trk, bool a_start) const;
+  // calculate the distance of a track from the border of the imaging volume
+  float dist_from_border(TrackletPtr a_trk, bool a_start) const;
 
-    // pointer to the track manager
-    TrackManager* manager;
+  // pointer to the track manager
+  TrackManager *manager;
 
-    // storage for the trajectories
-    unsigned int m_num_tracks = 0;
-    // std::vector<TrackletPtr> m_tracks;
+  // storage for the trajectories
+  unsigned int m_num_tracks = 0;
+  // std::vector<TrackletPtr> m_tracks;
 
-    // space to store a hash cube
-    HypercubeBin m_cube;
+  // space to store a hash cube
+  HypercubeBin m_cube;
 
-    // store the hypothesis generation parameters
-    PyHypothesisParams m_params;
+  // store the hypothesis generation parameters
+  PyHypothesisParams m_params;
 };
 
 #endif

--- a/btrack/include/inference.h
+++ b/btrack/include/inference.h
@@ -25,43 +25,43 @@
 #define RESERVE_STATE_SEQUENCE 1000
 
 class ObjectModel {
-   public:
-    ObjectModel(){};
-    ~ObjectModel(){};
+public:
+  ObjectModel(){};
+  ~ObjectModel(){};
 
-    // initialise with transition, emission and start matrices
-    ObjectModel(const Eigen::MatrixXd &transition,
-                const Eigen::MatrixXd &emission, const Eigen::MatrixXd &start);
+  // initialise with transition, emission and start matrices
+  ObjectModel(const Eigen::MatrixXd &transition,
+              const Eigen::MatrixXd &emission, const Eigen::MatrixXd &start);
 
-    // initialise with a uniform prior
-    ObjectModel(const Eigen::MatrixXd &transition,
-                const Eigen::MatrixXd &emission);
+  // initialise with a uniform prior
+  ObjectModel(const Eigen::MatrixXd &transition,
+              const Eigen::MatrixXd &emission);
 
-    // add a new observation to the chain
-    void update(const TrackObjectPtr new_object);
+  // add a new observation to the chain
+  void update(const TrackObjectPtr new_object);
 
-    // make a prediction from the model
-    Eigen::VectorXd predict();
+  // make a prediction from the model
+  Eigen::VectorXd predict();
 
-   private:
-    // the emission and transition matrices
-    Eigen::MatrixXd transition;
-    Eigen::MatrixXd emission;
+private:
+  // the emission and transition matrices
+  Eigen::MatrixXd transition;
+  Eigen::MatrixXd emission;
 
-    // store the number of states of the system
-    unsigned int states;
+  // store the number of states of the system
+  unsigned int states;
 
-    // space to store the current state
-    Eigen::VectorXd x_hat;
+  // space to store the current state
+  Eigen::VectorXd x_hat;
 
-    // store the state sequence
-    std::vector<unsigned short> sequence;
+  // store the state sequence
+  std::vector<unsigned short> sequence;
 
-    // make a prediction based on the model
-    void forward(const unsigned int observation);
+  // make a prediction based on the model
+  void forward(const unsigned int observation);
 
-    // backward algorithm
-    void backward();
+  // backward algorithm
+  void backward();
 };
 
 #endif

--- a/btrack/include/manager.h
+++ b/btrack/include/manager.h
@@ -48,170 +48,168 @@ void merge_tracks(const MergeHypothesis &merge);
 
 // Lineage tree node, used for building trees
 class LineageTreeNode {
-   public:
-    LineageTreeNode(){};
-    ~LineageTreeNode(){};
+public:
+  LineageTreeNode(){};
+  ~LineageTreeNode(){};
 
-    LineageTreeNode(TrackletPtr a_track) { m_track = a_track; };
+  LineageTreeNode(TrackletPtr a_track) { m_track = a_track; };
 
-    bool has_children(void) const { return m_track->has_children(); };
+  bool has_children(void) const { return m_track->has_children(); };
 
-    TrackletPtr m_track;
+  TrackletPtr m_track;
 
-    // pointers to left and right nodes
-    LineageTreeNode *m_left;
-    LineageTreeNode *m_right;
+  // pointers to left and right nodes
+  LineageTreeNode *m_left;
+  LineageTreeNode *m_right;
 
-    // store the generational depth, default depth is always zero
-    unsigned int m_depth = 0;
+  // store the generational depth, default depth is always zero
+  unsigned int m_depth = 0;
 };
 
 // A track manager class, behaves as if a simple vector of TrackletPtrs, but
 // contains functions to allow track merging and renaming. We only need a subset
 // of the vector functionality, so no need to subclass.
 class TrackManager {
-   public:
-    // default constructors and destructors
-    TrackManager() {
-        m_graph_nodes.reserve(RESERVE_GRAPH_NODES);
-        m_tracks.reserve(RESERVE_ALL_TRACKS);
-        // m_graph_edges.reserve(RESERVE_GRAPH_EDGES);
-    };
-    virtual ~TrackManager(){};
+public:
+  // default constructors and destructors
+  TrackManager() {
+    m_graph_nodes.reserve(RESERVE_GRAPH_NODES);
+    m_tracks.reserve(RESERVE_ALL_TRACKS);
+    // m_graph_edges.reserve(RESERVE_GRAPH_EDGES);
+  };
+  virtual ~TrackManager(){};
 
-    void clear(void) {
-        //
-    }
+  void clear(void) {
+    //
+  }
 
-    inline size_t num_nodes() const { return this->m_graph_nodes.size(); }
+  inline size_t num_nodes() const { return this->m_graph_nodes.size(); }
 
-    // return the number of tracks
-    inline size_t num_tracks(void) const { return this->m_tracks.size(); }
+  // return the number of tracks
+  inline size_t num_tracks(void) const { return this->m_tracks.size(); }
 
-    // return the number of graph edges
-    // this includes both the greedy and ILP edges
-    size_t num_edges(void) const;
+  // return the number of graph edges
+  // this includes both the greedy and ILP edges
+  size_t num_edges(void) const;
 
-    // return the number of hypotheses
-    inline size_t num_hypotheses(void) const {
-        return this->m_hypotheses.size();
-    }
+  // return the number of hypotheses
+  inline size_t num_hypotheses(void) const { return this->m_hypotheses.size(); }
 
-    // return a track by index
-    inline TrackletPtr operator[](const size_t a_idx) const {
-        return m_tracks[a_idx];
-    }
+  // return a track by index
+  inline TrackletPtr operator[](const size_t a_idx) const {
+    return m_tracks[a_idx];
+  }
 
-    // get a node
-    TrackObjectPtr get_node(const size_t a_idx) const {
-        return m_graph_nodes[a_idx];
-    }
+  // get a node
+  TrackObjectPtr get_node(const size_t a_idx) const {
+    return m_graph_nodes[a_idx];
+  }
 
-    // return a track by index
-    TrackletPtr get_track(const size_t a_idx) const { return m_tracks[a_idx]; }
+  // return a track by index
+  TrackletPtr get_track(const size_t a_idx) const { return m_tracks[a_idx]; }
 
-    // return track by ID
-    TrackletPtr get_track_by_ID(const size_t a_ID) const;
+  // return track by ID
+  TrackletPtr get_track_by_ID(const size_t a_ID) const;
 
-    // return a dummy object by index
-    TrackObjectPtr get_dummy(const int a_idx) const;
+  // return a dummy object by index
+  TrackObjectPtr get_dummy(const int a_idx) const;
 
-    // // return a hypothesis by index
-    // Hypothesis get_hypothesis(const size_t a_idx) const {
-    //   return m_hypotheses[a_idx];
-    // }
+  // // return a hypothesis by index
+  // Hypothesis get_hypothesis(const size_t a_idx) const {
+  //   return m_hypotheses[a_idx];
+  // }
 
-    // push a new node
-    inline void push_node(const TrackObjectPtr &a_node) {
-        m_graph_nodes.push_back(a_node);
-    }
+  // push a new node
+  inline void push_node(const TrackObjectPtr &a_node) {
+    m_graph_nodes.push_back(a_node);
+  }
 
-    // push a new track
-    inline void push_track(const TrackletPtr &a_trk) {
-        m_tracks.push_back(a_trk);
-    }
+  // push a new track
+  inline void push_track(const TrackletPtr &a_trk) {
+    m_tracks.push_back(a_trk);
+  }
 
-    // push a new hypothesis
-    inline void push_hypothesis(const Hypothesis &a_hypotheses) {
-        m_hypotheses.push_back(a_hypotheses);
-    }
+  // push a new hypothesis
+  inline void push_hypothesis(const Hypothesis &a_hypotheses) {
+    m_hypotheses.push_back(a_hypotheses);
+  }
 
-    // // reserve space for new tracks
-    // inline void reserve(const unsigned int a_reserve) {
-    //   m_tracks.reserve(a_reserve);
-    // }
+  // // reserve space for new tracks
+  // inline void reserve(const unsigned int a_reserve) {
+  //   m_tracks.reserve(a_reserve);
+  // }
 
-    // // test whether thse track manager is empty
-    // inline bool empty() const {
-    //   return m_tracks.empty();
-    // }
+  // // test whether thse track manager is empty
+  // inline bool empty() const {
+  //   return m_tracks.empty();
+  // }
 
-    // set a flag to store the candidate graph
-    void set_store_candidate_graph(const bool a_store_graph);
+  // set a flag to store the candidate graph
+  void set_store_candidate_graph(const bool a_store_graph);
 
-    // return the flag to store the candidate graph
-    inline bool get_store_candidate_graph(void) const {
-        return m_store_candidate_graph;
-    }
+  // return the flag to store the candidate graph
+  inline bool get_store_candidate_graph(void) const {
+    return m_store_candidate_graph;
+  }
 
-    // add a graph edge
-    void push_edge(const TrackObjectPtr &a_node_src,
-                   const TrackObjectPtr &a_node_dst, const float a_score,
-                   const unsigned int a_edge_type);
+  // add a graph edge
+  void push_edge(const TrackObjectPtr &a_node_src,
+                 const TrackObjectPtr &a_node_dst, const float a_score,
+                 const unsigned int a_edge_type);
 
-    // get a graph edge from the vector
-    PyGraphEdge get_edge(const size_t idx) const;
+  // get a graph edge from the vector
+  PyGraphEdge get_edge(const size_t idx) const;
 
-    // sort nodes
-    void sort_nodes(void) {
-        // sort the objects vector by time
-        std::sort(m_graph_nodes.begin(), m_graph_nodes.end(), compare_obj_time);
-    }
+  // sort nodes
+  void sort_nodes(void) {
+    // sort the objects vector by time
+    std::sort(m_graph_nodes.begin(), m_graph_nodes.end(), compare_obj_time);
+  }
 
-    // build trees from the data
-    void build_trees();
+  // build trees from the data
+  void build_trees();
 
-    // finalise the track output, giving dummy objects their unique (orthogonal)
-    // IDs for later retrieval, and any other cleanup required.
-    void finalise();
+  // finalise the track output, giving dummy objects their unique (orthogonal)
+  // IDs for later retrieval, and any other cleanup required.
+  void finalise();
 
-    // merges all tracks that have a link hypothesis, renumbers others and sets
-    // parent and root properties
-    void merge(const std::vector<Hypothesis> &a_hypotheses);
+  // merges all tracks that have a link hypothesis, renumbers others and sets
+  // parent and root properties
+  void merge(const std::vector<Hypothesis> &a_hypotheses);
 
-    // split a track with certain transitions
-    void split(const TrackletPtr &a_trk, const unsigned int a_label_i,
-               const unsigned int a_label_j);
+  // split a track with certain transitions
+  void split(const TrackletPtr &a_trk, const unsigned int a_label_i,
+             const unsigned int a_label_j);
 
-   private:
-    // // track maintenance
-    // void renumber();
-    // void purge();
+private:
+  // // track maintenance
+  // void renumber();
+  // void purge();
 
-    // a vector of track objects (i.e. nodes)
-    std::vector<TrackObjectPtr> m_graph_nodes;
+  // a vector of track objects (i.e. nodes)
+  std::vector<TrackObjectPtr> m_graph_nodes;
 
-    // a vector of tracklet objects
-    std::vector<TrackletPtr> m_tracks;
+  // a vector of tracklet objects
+  std::vector<TrackletPtr> m_tracks;
 
-    // set up some space for the trees, should we want these later
-    std::vector<LineageTreeNode> m_trees;
+  // set up some space for the trees, should we want these later
+  std::vector<LineageTreeNode> m_trees;
 
-    // a vector of dummy objects
-    std::vector<TrackObjectPtr> m_dummies;
+  // a vector of dummy objects
+  std::vector<TrackObjectPtr> m_dummies;
 
-    // store the graph edges, i.e. intermediate output of Bayesian updates
-    // and the graph hypotheses
-    std::vector<PyGraphEdge> m_graph_edges;
+  // store the graph edges, i.e. intermediate output of Bayesian updates
+  // and the graph hypotheses
+  std::vector<PyGraphEdge> m_graph_edges;
 
-    // store the raw hypotheses from the hypothesis engine
-    std::vector<Hypothesis> m_hypotheses;
+  // store the raw hypotheses from the hypothesis engine
+  std::vector<Hypothesis> m_hypotheses;
 
-    // make hypothesis maps
-    HypothesisMap<JoinHypothesis> m_links;
-    HypothesisMap<BranchHypothesis> m_branches;
+  // make hypothesis maps
+  HypothesisMap<JoinHypothesis> m_links;
+  HypothesisMap<BranchHypothesis> m_branches;
 
-    bool m_store_candidate_graph = false;
+  bool m_store_candidate_graph = false;
 };
 
 #endif

--- a/btrack/include/motion.h
+++ b/btrack/include/motion.h
@@ -31,71 +31,71 @@
 // Implements a Kalman filter for motion modelling in the tracker. Note that we
 // do not implement the 'control' updates from the full Kalman filter
 class MotionModel {
-   public:
-    // Default constructor for MotionModel
-    MotionModel(){};
+public:
+  // Default constructor for MotionModel
+  MotionModel(){};
 
-    // Initialise a motion model with matrices representing the motion model.
-    // A: State transition matrix
-    // H: Observation matrix
-    // P: Initial covariance estimate
-    // Q: Estimated error in process
-    // R: Estimated error in measurements
-    // Certain parameters are inferred from the shapes of the matrices, such as
-    // the number of states and measurements
-    MotionModel(const Eigen::MatrixXd &A, const Eigen::MatrixXd &H,
-                const Eigen::MatrixXd &P, const Eigen::MatrixXd &R,
-                const Eigen::MatrixXd &Q);
+  // Initialise a motion model with matrices representing the motion model.
+  // A: State transition matrix
+  // H: Observation matrix
+  // P: Initial covariance estimate
+  // Q: Estimated error in process
+  // R: Estimated error in measurements
+  // Certain parameters are inferred from the shapes of the matrices, such as
+  // the number of states and measurements
+  MotionModel(const Eigen::MatrixXd &A, const Eigen::MatrixXd &H,
+              const Eigen::MatrixXd &P, const Eigen::MatrixXd &R,
+              const Eigen::MatrixXd &Q);
 
-    // Default destructor
-    ~MotionModel(){};
+  // Default destructor
+  ~MotionModel(){};
 
-    // Setup the filter from a new object, set x_hat to the object position
-    void setup(const TrackObjectPtr new_object);
+  // Setup the filter from a new object, set x_hat to the object position
+  void setup(const TrackObjectPtr new_object);
 
-    // run an update of the Kalman filter using a new object observation
-    void update(const TrackObjectPtr new_object);
+  // run an update of the Kalman filter using a new object observation
+  void update(const TrackObjectPtr new_object);
 
-    // get the Kalman filter prediction
-    Prediction predict() const;
+  // get the Kalman filter prediction
+  Prediction predict() const;
 
-    // get the motion vector
-    Eigen::Vector3d get_motion_vector() const { return motion_vector; }
+  // get the motion vector
+  Eigen::Vector3d get_motion_vector() const { return motion_vector; }
 
-    // return the system dimensions
-    void dimensions(unsigned int *m, unsigned int *s) const {
-        *m = measurements;
-        *s = states;
-    };
+  // return the system dimensions
+  void dimensions(unsigned int *m, unsigned int *s) const {
+    *m = measurements;
+    *s = states;
+  };
 
-   private:
-    // matrices for Kalman filter
-    Eigen::MatrixXd A;
-    Eigen::MatrixXd H;
-    Eigen::MatrixXd P;
-    Eigen::MatrixXd R;
-    Eigen::MatrixXd Q;
-    Eigen::MatrixXd K;
+private:
+  // matrices for Kalman filter
+  Eigen::MatrixXd A;
+  Eigen::MatrixXd H;
+  Eigen::MatrixXd P;
+  Eigen::MatrixXd R;
+  Eigen::MatrixXd Q;
+  Eigen::MatrixXd K;
 
-    // system dimensions
-    unsigned int measurements;
-    unsigned int states;
+  // system dimensions
+  unsigned int measurements;
+  unsigned int states;
 
-    // store states
-    Eigen::VectorXd x_hat;
-    Eigen::VectorXd x_hat_new;
+  // store states
+  Eigen::VectorXd x_hat;
+  Eigen::VectorXd x_hat_new;
 
-    // motion vector
-    Eigen::Vector3d motion_vector;
+  // motion vector
+  Eigen::Vector3d motion_vector;
 
-    // an identity matrix
-    Eigen::MatrixXd I;
+  // an identity matrix
+  Eigen::MatrixXd I;
 
-    // initialised is set to true by the constructor
-    bool initialised = false;
+  // initialised is set to true by the constructor
+  bool initialised = false;
 
-    // time step which will default to one
-    double dt;
+  // time step which will default to one
+  double dt;
 };
 
 #endif

--- a/btrack/include/pdf.h
+++ b/btrack/include/pdf.h
@@ -28,16 +28,16 @@
 
 // #pragma once
 namespace ProbabilityDensityFunctions {
-double cheat_multivariate_normal(const TrackletPtr& trk,
-                                 const TrackObjectPtr& obj);
+double cheat_multivariate_normal(const TrackletPtr &trk,
+                                 const TrackObjectPtr &obj);
 
-double multivariate_erf(const TrackletPtr& trk, const TrackObjectPtr& obj,
+double multivariate_erf(const TrackletPtr &trk, const TrackObjectPtr &obj,
                         const double accuracy);
 
-double cosine_similarity(const TrackletPtr& trk, const TrackObjectPtr& obj);
+double cosine_similarity(const TrackletPtr &trk, const TrackObjectPtr &obj);
 
-double soft_cosine_similarity(const TrackletPtr& trk,
-                              const TrackObjectPtr& obj);
-}  // namespace ProbabilityDensityFunctions
+double soft_cosine_similarity(const TrackletPtr &trk,
+                              const TrackObjectPtr &obj);
+} // namespace ProbabilityDensityFunctions
 
 #endif

--- a/btrack/include/tracklet.h
+++ b/btrack/include/tracklet.h
@@ -28,118 +28,118 @@
 // Tracklet object. A container class to keep the list of track objects as well
 // as a dedicated motion and object models for the object.
 class Tracklet {
-   public:
-    // default constructor for Tracklet
-    Tracklet() : remove_flag(false){};
+public:
+  // default constructor for Tracklet
+  Tracklet() : remove_flag(false){};
 
-    // construct Tracklet using a new ID, new object and model specific
-    // parameters
-    Tracklet(const unsigned int new_ID, const TrackObjectPtr& new_object,
-             const unsigned int max_lost, const MotionModel& model);
+  // construct Tracklet using a new ID, new object and model specific
+  // parameters
+  Tracklet(const unsigned int new_ID, const TrackObjectPtr &new_object,
+           const unsigned int max_lost, const MotionModel &model);
 
-    // default destructor for Tracklet
-    ~Tracklet(){};
+  // default destructor for Tracklet
+  ~Tracklet(){};
 
-    // append a new track object to the trajectory, update flag tells the
-    // function whether to update the motion model or not - new tracks should
-    // not update the motion model
-    void append(const TrackObjectPtr& new_object, bool update);
-    void append(const TrackObjectPtr& new_object) { append(new_object, true); }
-    // append a dummy object to the trajectory in case of a missed observation
-    // only update the predicted position in cases where we're using a motion
-    // model, default with no args is to update the position
-    void append_dummy(const bool update_position);
-    void append_dummy() { append_dummy(true); };
+  // append a new track object to the trajectory, update flag tells the
+  // function whether to update the motion model or not - new tracks should
+  // not update the motion model
+  void append(const TrackObjectPtr &new_object, bool update);
+  void append(const TrackObjectPtr &new_object) { append(new_object, true); }
+  // append a dummy object to the trajectory in case of a missed observation
+  // only update the predicted position in cases where we're using a motion
+  // model, default with no args is to update the position
+  void append_dummy(const bool update_position);
+  void append_dummy() { append_dummy(true); };
 
-    // return the length of the trajectory
-    unsigned int length() const { return track.size(); };
+  // return the length of the trajectory
+  unsigned int length() const { return track.size(); };
 
-    // return the track duration
-    double duration() const {
-        assert(!track.empty());
-        return track.back()->t - track.front()->t;
-    }
+  // return the track duration
+  double duration() const {
+    assert(!track.empty());
+    return track.back()->t - track.front()->t;
+  }
 
-    // return a boolean representing the status (active/inactive) of the track
-    bool active() const { return lost <= max_lost; };
+  // return a boolean representing the status (active/inactive) of the track
+  bool active() const { return lost <= max_lost; };
 
-    // trim trailing dummy objects - should only be called when the tracking is
-    // finished
-    bool trim();
+  // trim trailing dummy objects - should only be called when the tracking is
+  // finished
+  bool trim();
 
-    // get the track data as a C-type array
-    // TODO(arl): implement this
-    double* get();
+  // get the track data as a C-type array
+  // TODO(arl): implement this
+  double *get();
 
-    // get the position coordinates over time
-    // TODO(arl): implement these
-    std::vector<float> x();
-    std::vector<float> y();
-    std::vector<float> z();
-    std::vector<unsigned int> t();
-    std::vector<bool> dummy();
+  // get the position coordinates over time
+  // TODO(arl): implement these
+  std::vector<float> x();
+  std::vector<float> y();
+  std::vector<float> z();
+  std::vector<unsigned int> t();
+  std::vector<bool> dummy();
 
-    // get the current position from the last known object
-    Eigen::Vector3d position() const {
-        assert(!track.empty());
-        return track.back()->position();
-    };
+  // get the current position from the last known object
+  Eigen::Vector3d position() const {
+    assert(!track.empty());
+    return track.back()->position();
+  };
 
-    // set the track to lost - permanently!
-    void set_lost() { lost = max_lost + 1; }
+  // set the track to lost - permanently!
+  void set_lost() { lost = max_lost + 1; }
 
-    // check to see whether this should be removed;
-    bool to_remove() const { return remove_flag; }
+  // check to see whether this should be removed;
+  bool to_remove() const { return remove_flag; }
 
-    // set a flag to remove this track
-    void to_remove(bool a_remove) { remove_flag = a_remove; }
+  // set a flag to remove this track
+  void to_remove(bool a_remove) { remove_flag = a_remove; }
 
-    // does this track have children
-    bool has_children() const { return (child_one != child_two); }
+  // does this track have children
+  bool has_children() const { return (child_one != child_two); }
 
-    // get the latest prediction from the motion model. Note that the current
-    // prediction from the Tracklet object is different to the prediction of the
-    // motion model. The tracklet adds any extra model information to the
-    // last known position, while the motion model is the filtered version of
-    // the data which may contain some lag. This is a critical part of the
-    // prediction
-    // TODO(arl): make this model agnostic
-    Prediction predict() const;
+  // get the latest prediction from the motion model. Note that the current
+  // prediction from the Tracklet object is different to the prediction of the
+  // motion model. The tracklet adds any extra model information to the
+  // last known position, while the motion model is the filtered version of
+  // the data which may contain some lag. This is a critical part of the
+  // prediction
+  // TODO(arl): make this model agnostic
+  Prediction predict() const;
 
-    // Identifier for the tracklet
-    unsigned int ID = 0;
+  // Identifier for the tracklet
+  unsigned int ID = 0;
 
-    // these are vectors storing the predicted new position and the Kalman
-    // output as well as the pointers to the track objects comprising the
-    // trajectory
-    std::vector<Prediction> kalman;
-    std::vector<Prediction> prediction;
-    std::vector<TrackObjectPtr> track;
+  // these are vectors storing the predicted new position and the Kalman
+  // output as well as the pointers to the track objects comprising the
+  // trajectory
+  std::vector<Prediction> kalman;
+  std::vector<Prediction> prediction;
+  std::vector<TrackObjectPtr> track;
 
-    // counter for number of consecutive lost/dummy observations
-    unsigned int lost = 0;
+  // counter for number of consecutive lost/dummy observations
+  unsigned int lost = 0;
 
-    // store the root, parent and original IDs
-    unsigned int root = 0;
-    unsigned int parent = 0;
-    unsigned int child_one = 0;
-    unsigned int child_two = 0;
-    unsigned int renamed_ID;
-    unsigned int fate = TYPE_undef;
-    unsigned int generation = 0;
+  // store the root, parent and original IDs
+  unsigned int root = 0;
+  unsigned int parent = 0;
+  unsigned int child_one = 0;
+  unsigned int child_two = 0;
+  unsigned int renamed_ID;
+  unsigned int fate = TYPE_undef;
+  unsigned int generation = 0;
 
-   private:
-    // if the lost counter exceeds max_lost, the track is considered inactive
-    unsigned int max_lost = MAX_LOST;
+private:
+  // if the lost counter exceeds max_lost, the track is considered inactive
+  unsigned int max_lost = MAX_LOST;
 
-    // set the remove flag
-    bool remove_flag = false;
+  // set the remove flag
+  bool remove_flag = false;
 
-    // motion model
-    MotionModel motion_model;
+  // motion model
+  MotionModel motion_model;
 
-    // object model
-    ObjectModel object_model;
+  // object model
+  ObjectModel object_model;
 };
 
 // a shared pointer for tracklets

--- a/btrack/include/types.h
+++ b/btrack/include/types.h
@@ -27,125 +27,104 @@
 
 // Python structure for external interface
 extern "C" struct PyTrackObject {
-    long ID;
-    double x;
-    double y;
-    double z;
-    unsigned int t;
-    bool dummy;
-    unsigned int states;
-    unsigned int label;
-    unsigned int n_features;
-    double* features;
+  long ID;
+  double x;
+  double y;
+  double z;
+  unsigned int t;
+  bool dummy;
+  unsigned int states;
+  unsigned int label;
+  unsigned int n_features;
+  double *features;
 };
 
 // Output back to Python with some tracking statistics
 extern "C" struct PyTrackInfo {
-    unsigned int error;
-    unsigned int n_tracks;
-    unsigned int n_active;
-    unsigned int n_conflicts;
-    unsigned int n_lost;
-    float t_update_belief;
-    float t_update_link;
-    float t_total_time;
-    float p_link;
-    float p_lost;
-    bool complete;
+  unsigned int error;
+  unsigned int n_tracks;
+  unsigned int n_active;
+  unsigned int n_conflicts;
+  unsigned int n_lost;
+  float t_update_belief;
+  float t_update_link;
+  float t_total_time;
+  float p_link;
+  float p_lost;
+  bool complete;
 
-    // default constructor
-    PyTrackInfo()
-        : error(ERROR_none),
-          n_tracks(0),
-          n_active(0),
-          n_conflicts(0),
-          n_lost(0),
-          t_update_belief(0),
-          t_update_link(0),
-          t_total_time(0),
-          p_link(0),
-          p_lost(0),
-          complete(false){};
+  // default constructor
+  PyTrackInfo()
+      : error(ERROR_none), n_tracks(0), n_active(0), n_conflicts(0), n_lost(0),
+        t_update_belief(0), t_update_link(0), t_total_time(0), p_link(0),
+        p_lost(0), complete(false){};
 };
 
 // structure to return the Bayesian belief matrix as a series of graph edges
 extern "C" struct PyGraphEdge {
-    long source;
-    long target;
-    double score;
-    unsigned int type = GRAPH_EDGE_link;
+  long source;
+  long target;
+  double score;
+  unsigned int type = GRAPH_EDGE_link;
 };
 
 // TrackObject stores the data of each object in the field of view. Is
 // essentially a parallel of the PyTrackObject class.
 class TrackObject {
-   public:
-    // Start a new tracklet without any prior information.
-    TrackObject()
-        : ID(0),
-          x(0.),
-          y(0.),
-          z(0.),
-          t(0),
-          dummy(true),
-          label(0),
-          n_features(0){};
+public:
+  // Start a new tracklet without any prior information.
+  TrackObject()
+      : ID(0), x(0.), y(0.), z(0.), t(0), dummy(true), label(0),
+        n_features(0){};
 
-    // Instantiate a track object from an existing PyTrackObject
-    TrackObject(const PyTrackObject& trk)
-        : ID(trk.ID),
-          x(trk.x),
-          y(trk.y),
-          z(trk.z),
-          t(trk.t),
-          dummy(trk.dummy),
-          label(trk.label),
-          states(trk.states),
-          n_features(trk.n_features),
-          features(Eigen::Map<Eigen::VectorXd>(trk.features, trk.n_features)){};
+  // Instantiate a track object from an existing PyTrackObject
+  TrackObject(const PyTrackObject &trk)
+      : ID(trk.ID), x(trk.x), y(trk.y), z(trk.z), t(trk.t), dummy(trk.dummy),
+        label(trk.label), states(trk.states), n_features(trk.n_features),
+        features(Eigen::Map<Eigen::VectorXd>(trk.features, trk.n_features)){};
 
-    // Default destructor
-    ~TrackObject(){};
+  // Default destructor
+  ~TrackObject(){};
 
-    // xyzt position, dummy flag and class label, note that the ID can be
-    // negative, indicating a dummy object
-    long ID;
-    double x;
-    double y;
-    double z;
-    unsigned int t;
-    bool dummy;
-    unsigned int label;
-    unsigned int states;
-    unsigned int n_features;
+  // xyzt position, dummy flag and class label, note that the ID can be
+  // negative, indicating a dummy object
+  long ID;
+  double x;
+  double y;
+  double z;
+  unsigned int t;
+  bool dummy;
+  unsigned int label;
+  unsigned int states;
+  unsigned int n_features;
 
-    // store object features
-    Eigen::VectorXd features;
+  // store object features
+  Eigen::VectorXd features;
 
-    // return the current position of the track object
-    Eigen::Vector3d position() const {
-        Eigen::Vector3d p;
-        p << x, y, z;
-        return p;
-    };
+  // return the current position of the track object
+  Eigen::Vector3d position() const {
+    Eigen::Vector3d p;
+    p << x, y, z;
+    return p;
+  };
 
-    // return this object as a pytrack object
-    PyTrackObject get_pytrack_object() const {
-        PyTrackObject p = PyTrackObject();
-        p.ID = this->ID;
-        p.x = this->x;
-        p.y = this->y;
-        p.z = this->z;
-        p.t = this->t;
-        p.dummy = this->dummy;
-        p.label = this->label;
-        p.states = this->states;
-        return p;
-    };
+  // return this object as a pytrack object
+  PyTrackObject get_pytrack_object() const {
+    PyTrackObject p = PyTrackObject();
+    p.ID = this->ID;
+    p.x = this->x;
+    p.y = this->y;
+    p.z = this->z;
+    p.t = this->t;
+    p.dummy = this->dummy;
+    p.label = this->label;
+    p.states = this->states;
+    return p;
+  };
 
-   private:
-    // Store a reference to the original object?
-    // const PyTrackObject* original_object;
+private:
+  // Store a reference to the original object?
+  // const PyTrackObject* original_object;
 };
 
 // type definition for a track object pointer, minimising copying
@@ -153,67 +132,67 @@ typedef std::shared_ptr<TrackObject> TrackObjectPtr;
 
 // Structure for MotionModel predictions
 struct Prediction {
-    // position and error predictions
-    Eigen::VectorXd mu;
-    Eigen::MatrixXd covar;
+  // position and error predictions
+  Eigen::VectorXd mu;
+  Eigen::MatrixXd covar;
 
-    // constructors
-    // TODO(arl): the default constructor defaults to six states
-    Prediction() {
-        mu.setZero(6, 1);
-        covar.setIdentity(6, 6);
-    }
-    Prediction(const Eigen::VectorXd& a_mu, const Eigen::MatrixXd& a_covar)
-        : mu(a_mu), covar(a_covar){};
+  // constructors
+  // TODO(arl): the default constructor defaults to six states
+  Prediction() {
+    mu.setZero(6, 1);
+    covar.setIdentity(6, 6);
+  }
+  Prediction(const Eigen::VectorXd &a_mu, const Eigen::MatrixXd &a_covar)
+      : mu(a_mu), covar(a_covar){};
 };
 
 // Comparison object to order track objects ready for tracking.
 inline bool compare_obj_time(const TrackObjectPtr trackobj_1,
                              const TrackObjectPtr trackobj_2) {
-    return (trackobj_1->t < trackobj_2->t);
+  return (trackobj_1->t < trackobj_2->t);
 }
 
 // Structure to determine the imaging volume from the observations
 struct ImagingVolume {
-    // minimum and maximum dimensions of the volume from observations
-    Eigen::Vector3d min_xyz;
-    Eigen::Vector3d max_xyz;
+  // minimum and maximum dimensions of the volume from observations
+  Eigen::Vector3d min_xyz;
+  Eigen::Vector3d max_xyz;
 
-    // default constructor
-    ImagingVolume() {
-        min_xyz.fill(kInfinity);
-        max_xyz.fill(-kInfinity);
-    };
+  // default constructor
+  ImagingVolume() {
+    min_xyz.fill(kInfinity);
+    max_xyz.fill(-kInfinity);
+  };
 
-    // update with an observation
-    void update(const TrackObjectPtr obj) {
-        min_xyz = min_xyz.cwiseMin(obj->position());
-        max_xyz = max_xyz.cwiseMax(obj->position());
-    };
+  // update with an observation
+  void update(const TrackObjectPtr obj) {
+    min_xyz = min_xyz.cwiseMin(obj->position());
+    max_xyz = max_xyz.cwiseMax(obj->position());
+  };
 
-    // set the imaging volume (note that this could be overwritten...)
-    void set_volume(const double* a_volume) {
-        assert(a_volume[0] <= a_volume[1]);
-        assert(a_volume[2] <= a_volume[3]);
-        assert(a_volume[4] <= a_volume[5]);
+  // set the imaging volume (note that this could be overwritten...)
+  void set_volume(const double *a_volume) {
+    assert(a_volume[0] <= a_volume[1]);
+    assert(a_volume[2] <= a_volume[3]);
+    assert(a_volume[4] <= a_volume[5]);
 
-        min_xyz << a_volume[0], a_volume[2], a_volume[4];
-        max_xyz << a_volume[1], a_volume[3], a_volume[5];
+    min_xyz << a_volume[0], a_volume[2], a_volume[4];
+    max_xyz << a_volume[1], a_volume[3], a_volume[5];
+  }
+
+  // test whether an object lies within the volume
+  bool inside(const Eigen::Vector3d &position) const {
+    if (position(0) >= min_xyz(0) && position(0) <= max_xyz(0) &&
+        position(1) >= min_xyz(1) && position(1) <= max_xyz(1) &&
+        position(2) >= min_xyz(2) && position(2) <= max_xyz(2)) {
+      return true;
+    } else {
+      return false;
     }
+  }
 
-    // test whether an object lies within the volume
-    bool inside(const Eigen::Vector3d& position) const {
-        if (position(0) >= min_xyz(0) && position(0) <= max_xyz(0) &&
-            position(1) >= min_xyz(1) && position(1) <= max_xyz(1) &&
-            position(2) >= min_xyz(2) && position(2) <= max_xyz(2)) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    // test whether a dataset is 2D, i.e. all z-values are the same
-    bool is_2D(void) const { return (min_xyz(2) == max_xyz(2)); }
+  // test whether a dataset is 2D, i.e. all z-values are the same
+  bool is_2D(void) const { return (min_xyz(2) == max_xyz(2)); }
 };
 
 // Hypothesis map is a sort of dictionary of lists, and can be used to store
@@ -225,56 +204,55 @@ struct ImagingVolume {
 //  ii. enumerate different merge/branch hypotheses in the optimiser
 //
 // types are: LinkHypothesis and MergeHypothesis
-template <typename T>
-class HypothesisMap {
-   public:
-    // default constructor
-    HypothesisMap(){};
+template <typename T> class HypothesisMap {
+public:
+  // default constructor
+  HypothesisMap(){};
 
-    // default destructor
-    ~HypothesisMap(){};
+  // default destructor
+  ~HypothesisMap(){};
 
-    // construct a map with n_entries, which are initialised with empty vectors
-    // of hypotheses
-    HypothesisMap(const unsigned int n_entries) {
-        m_hypothesis_map.clear();
-        m_hypothesis_map.reserve(n_entries);
-        for (size_t i = 0; i < n_entries; i++) {
-            m_hypothesis_map.push_back(std::vector<T>());
-        }
-    };
+  // construct a map with n_entries, which are initialised with empty vectors
+  // of hypotheses
+  HypothesisMap(const unsigned int n_entries) {
+    m_hypothesis_map.clear();
+    m_hypothesis_map.reserve(n_entries);
+    for (size_t i = 0; i < n_entries; i++) {
+      m_hypothesis_map.push_back(std::vector<T>());
+    }
+  };
 
-    // push a new hypothesis into the entry bin
-    inline void push(const unsigned int& bin, T lnk) {
-        m_hypothesis_map[bin].push_back(lnk);
-        m_empty = false;
-    };
+  // push a new hypothesis into the entry bin
+  inline void push(const unsigned int &bin, T lnk) {
+    m_hypothesis_map[bin].push_back(lnk);
+    m_empty = false;
+  };
 
-    // return the number of entries in the HypothesisMap
-    size_t size() const { return m_hypothesis_map.size(); };
+  // return the number of entries in the HypothesisMap
+  size_t size() const { return m_hypothesis_map.size(); };
 
-    // is the container completely empty?
-    inline bool empty() const { return m_empty; }
+  // is the container completely empty?
+  inline bool empty() const { return m_empty; }
 
-    // return the vector of hypotheses in this bin
-    inline std::vector<T> operator[](const unsigned int bin) const {
-        // assert(bin < size());
-        if (bin >= size())
-            return std::vector<T>();  // return empty if no bin exists
-        return m_hypothesis_map[bin];
-    };
+  // return the vector of hypotheses in this bin
+  inline std::vector<T> operator[](const unsigned int bin) const {
+    // assert(bin < size());
+    if (bin >= size())
+      return std::vector<T>(); // return empty if no bin exists
+    return m_hypothesis_map[bin];
+  };
 
-    // count the number of hypotheses in this bin
-    const size_t count(const unsigned int& idx) const {
-        return m_hypothesis_map[idx].size();
-    };
+  // count the number of hypotheses in this bin
+  const size_t count(const unsigned int &idx) const {
+    return m_hypothesis_map[idx].size();
+  };
 
-   private:
-    // the map of hypotheses
-    std::vector<std::vector<T> > m_hypothesis_map;
+private:
+  // the map of hypotheses
+  std::vector<std::vector<T>> m_hypothesis_map;
 
-    // empty flag, reset to false if we add a hypothesis
-    bool m_empty = true;
+  // empty flag, reset to false if we add a hypothesis
+  bool m_empty = true;
 };
 
 #endif

--- a/btrack/include/updates.h
+++ b/btrack/include/updates.h
@@ -22,36 +22,36 @@
 // use a bitmask to determine which combination of features to use
 inline bool _use_features(const unsigned int features,
                           const unsigned int bitmask) {
-    return ((features & bitmask) == bitmask);
+  return ((features & bitmask) == bitmask);
 };
 
 // deals with setting which features to use during tracking or hypothesis
 // generation. This class is inherited by both BayesianTracker and
 // HypothesisEngine to provide a common interface
 class UpdateFeatures {
-   public:
-    // set the features to use while updating the Bayesian belief matrix
-    inline void set_update_features(const unsigned int update_features) {
-        m_update_features = update_features;
-    };
+public:
+  // set the features to use while updating the Bayesian belief matrix
+  inline void set_update_features(const unsigned int update_features) {
+    m_update_features = update_features;
+  };
 
-    inline const unsigned int get_update_features(void) const {
-        return m_update_features;
-    };
+  inline const unsigned int get_update_features(void) const {
+    return m_update_features;
+  };
 
-    inline bool use_motion_features(void) const {
-        return _use_features(m_update_features, USE_MOTION_FEATURES);
-    };
+  inline bool use_motion_features(void) const {
+    return _use_features(m_update_features, USE_MOTION_FEATURES);
+  };
 
-    inline bool use_visual_features(void) const {
-        return _use_features(m_update_features, USE_VISUAL_FEATURES);
-    };
+  inline bool use_visual_features(void) const {
+    return _use_features(m_update_features, USE_VISUAL_FEATURES);
+  };
 
-   protected:
-    unsigned int m_update_features;
+protected:
+  unsigned int m_update_features;
 
-   private:
-    //
+private:
+  //
 };
 
 #endif

--- a/btrack/include/wrapper.h
+++ b/btrack/include/wrapper.h
@@ -24,115 +24,114 @@
 // Interface class to coordinate the tracker, hypothesis engine and optimisation
 // Also provides a simple interface for the python facing code.
 class InterfaceWrapper {
-   public:
-    // default constructors/destructors
-    InterfaceWrapper();
-    virtual ~InterfaceWrapper();
+public:
+  // default constructors/destructors
+  InterfaceWrapper();
+  virtual ~InterfaceWrapper();
 
-    // check that this is the correct version of the shared lib
-    bool check_library_version(const uint8_t a_major, const uint8_t a_minor,
-                               const uint8_t a_build) const;
+  // check that this is the correct version of the shared lib
+  bool check_library_version(const uint8_t a_major, const uint8_t a_minor,
+                             const uint8_t a_build) const;
 
-    // set the tracker to store the candidate graph
-    void set_store_candidate_graph(const bool a_store_graph);
+  // set the tracker to store the candidate graph
+  void set_store_candidate_graph(const bool a_store_graph);
 
-    // set the update mode of the tracker (e.g. EXACT, APPROXIMATE, CUDA etc)
-    void set_update_mode(const unsigned int a_update_mode);
+  // set the update mode of the tracker (e.g. EXACT, APPROXIMATE, CUDA etc)
+  void set_update_mode(const unsigned int a_update_mode);
 
-    // set the update features to use by the tracker (e.g. motion, visual)
-    void set_update_features(const unsigned int a_update_features);
+  // set the update features to use by the tracker (e.g. motion, visual)
+  void set_update_features(const unsigned int a_update_features);
 
-    // check the update mode
-    bool check_update_mode(const unsigned int a_update_mode) const;
+  // check the update mode
+  bool check_update_mode(const unsigned int a_update_mode) const;
 
-    // check the update features
-    bool check_update_features(const unsigned int a_update_features) const;
+  // check the update features
+  bool check_update_features(const unsigned int a_update_features) const;
 
-    // tracking and basic data handling
-    void set_motion_model(const unsigned int measurements,
-                          const unsigned int states, double* A, double* H,
-                          double* P, double* Q, double* R, double dt,
-                          double accuracy, unsigned int max_lost,
-                          double prob_not_assign);
+  // tracking and basic data handling
+  void set_motion_model(const unsigned int measurements,
+                        const unsigned int states, double *A, double *H,
+                        double *P, double *Q, double *R, double dt,
+                        double accuracy, unsigned int max_lost,
+                        double prob_not_assign);
 
-    // set the maximum search radius
-    void set_max_search_radius(const float max_search_radius);
+  // set the maximum search radius
+  void set_max_search_radius(const float max_search_radius);
 
-    // append an object to the tracker
-    void append(const PyTrackObject a_object);
+  // append an object to the tracker
+  void append(const PyTrackObject a_object);
 
-    // run the tracking
-    const PyTrackInfo* track();
+  // run the tracking
+  const PyTrackInfo *track();
 
-    // step through the tracking by n steps
-    const PyTrackInfo* step(const unsigned int a_steps);
+  // step through the tracking by n steps
+  const PyTrackInfo *step(const unsigned int a_steps);
 
-    // get the internal ID of the track
-    unsigned int get_ID(const unsigned int a_ID) const;
+  // get the internal ID of the track
+  unsigned int get_ID(const unsigned int a_ID) const;
 
-    // get a track by ID, returns the number of objects in the track
-    unsigned int get_track(double* output, const unsigned int a_ID) const;
+  // get a track by ID, returns the number of objects in the track
+  unsigned int get_track(double *output, const unsigned int a_ID) const;
 
-    // get the object IDs of the objects in the track
-    unsigned int get_refs(int* output, const unsigned int a_ID) const;
+  // get the object IDs of the objects in the track
+  unsigned int get_refs(int *output, const unsigned int a_ID) const;
 
-    // get the parent ID
-    unsigned int get_parent(const unsigned int a_ID) const;
+  // get the parent ID
+  unsigned int get_parent(const unsigned int a_ID) const;
 
-    // get the root ID
-    unsigned int get_root(const unsigned int a_ID) const;
+  // get the root ID
+  unsigned int get_root(const unsigned int a_ID) const;
 
-    // get the children IDs
-    unsigned int get_children(int* children, const unsigned int a_ID) const;
+  // get the children IDs
+  unsigned int get_children(int *children, const unsigned int a_ID) const;
 
-    // get the fate of the track
-    unsigned int get_fate(const unsigned int a_ID) const;
+  // get the fate of the track
+  unsigned int get_fate(const unsigned int a_ID) const;
 
-    // get the generational depth of the track in the tree
-    unsigned int get_generation(const unsigned int a_ID) const;
+  // get the generational depth of the track in the tree
+  unsigned int get_generation(const unsigned int a_ID) const;
 
-    // get a dummy object by reference
-    PyTrackObject get_dummy(const int a_ID);
+  // get a dummy object by reference
+  PyTrackObject get_dummy(const int a_ID);
 
-    // get the length of a track
-    unsigned int track_length(const unsigned int a_ID) const;
+  // get the length of a track
+  unsigned int track_length(const unsigned int a_ID) const;
 
-    // motion model related data
-    unsigned int get_kalman_mu(double* output, const unsigned int a_ID) const;
-    unsigned int get_kalman_covar(double* output,
-                                  const unsigned int a_ID) const;
-    unsigned int get_kalman_pred(double* output, const unsigned int a_ID) const;
-    unsigned int get_label(unsigned int* output, const unsigned int a_ID) const;
+  // motion model related data
+  unsigned int get_kalman_mu(double *output, const unsigned int a_ID) const;
+  unsigned int get_kalman_covar(double *output, const unsigned int a_ID) const;
+  unsigned int get_kalman_pred(double *output, const unsigned int a_ID) const;
+  unsigned int get_label(unsigned int *output, const unsigned int a_ID) const;
 
-    // return the number of tracks
-    unsigned int size() const { return manager.num_tracks(); }
+  // return the number of tracks
+  unsigned int size() const { return manager.num_tracks(); }
 
-    // get/set the imaging volume
-    void set_volume(const double* a_volume);
-    void get_volume(double* a_volume) const;
+  // get/set the imaging volume
+  void set_volume(const double *a_volume);
+  void get_volume(double *a_volume) const;
 
-    // get the graph edges of the bayesian belief matrix
-    unsigned int num_edges() const { return manager.num_edges(); }
+  // get the graph edges of the bayesian belief matrix
+  unsigned int num_edges() const { return manager.num_edges(); }
 
-    // get a graph edge
-    PyGraphEdge get_graph_edge(const size_t a_ID);
+  // get a graph edge
+  PyGraphEdge get_graph_edge(const size_t a_ID);
 
-    // hypothesis generation, returns number of hypotheses found
-    unsigned int create_hypotheses(PyHypothesisParams params,
-                                   const unsigned int a_start_frame,
-                                   const unsigned int a_end_frame);
+  // hypothesis generation, returns number of hypotheses found
+  unsigned int create_hypotheses(PyHypothesisParams params,
+                                 const unsigned int a_start_frame,
+                                 const unsigned int a_end_frame);
 
-    // return a specific hypothesis
-    PyHypothesis get_hypothesis(const unsigned int a_ID);
+  // return a specific hypothesis
+  PyHypothesis get_hypothesis(const unsigned int a_ID);
 
-    // merge tracks based on optimisation
-    void merge(unsigned int* a_hypotheses, unsigned int n_hypotheses);
+  // merge tracks based on optimisation
+  void merge(unsigned int *a_hypotheses, unsigned int n_hypotheses);
 
-   private:
-    // the tracker, track manager and hypothesis engines
-    BayesianTracker tracker;
-    HypothesisEngine h_engine;
-    TrackManager manager;
+private:
+  // the tracker, track manager and hypothesis engines
+  BayesianTracker tracker;
+  HypothesisEngine h_engine;
+  TrackManager manager;
 };
 
 #endif

--- a/btrack/io/_localization.py
+++ b/btrack/io/_localization.py
@@ -46,7 +46,6 @@ def _centroids_from_single_arr(
 
     # if class id is specified then extract that property first
     if assign_class_ID:
-
         # ensure regionprops can properly read label image
         labeled = label(segmentation)
 
@@ -203,7 +202,6 @@ def segmentation_to_objects(  # noqa: PLR0913
     if inspect.isgeneratorfunction(segmentation) or isinstance(
         segmentation, Generator
     ):
-
         for frame, seg in enumerate(segmentation):
             intens = next(intensity_image) if USE_INTENSITY else None
             _centroids = _centroids_from_single_arr(
@@ -220,7 +218,6 @@ def segmentation_to_objects(  # noqa: PLR0913
             centroids = _concat_centroids(centroids, _centroids)
 
     else:
-
         if segmentation.ndim not in (
             Dimensionality.THREE,
             Dimensionality.FOUR,

--- a/btrack/io/hdf.py
+++ b/btrack/io/hdf.py
@@ -129,7 +129,6 @@ class HDF5FileHandler:
         *,
         obj_type: str = "obj_type_1",
     ):
-
         self._f_expr = None  # DO NOT USE
         self.object_type = obj_type
 

--- a/btrack/napari/reader.py
+++ b/btrack/napari/reader.py
@@ -63,7 +63,6 @@ def reader_function(path: PathOrPaths) -> List[LayerDataTuple]:
 
     for _path in paths:
         with HDF5FileHandler(_path, "r") as hdf:
-
             # get the segmentation if there is one
             segmentation = hdf.segmentation
             if segmentation is not None:
@@ -71,7 +70,6 @@ def reader_function(path: PathOrPaths) -> List[LayerDataTuple]:
 
             # iterate over object types and create a layer for each
             for obj_type in hdf.object_types:
-
                 # set the object type, and retrieve the tracks
                 hdf.object_type = obj_type
 

--- a/btrack/optimise/optimiser.py
+++ b/btrack/optimise/optimiser.py
@@ -141,7 +141,6 @@ class TrackOptimiser:
         # iterate over the hypotheses and build the constraints
         # TODO(arl): vectorize this for increased performance
         for counter, h in enumerate(self.hypotheses):
-
             # set the hypothesis score
             rho[counter] = h.log_likelihood
 

--- a/btrack/src/bayes.cc
+++ b/btrack/src/bayes.cc
@@ -20,22 +20,22 @@ using namespace BayesianUpdateFunctions;
 
 std::tuple<double, double> BayesianUpdateFunctions::safe_bayesian_update(
     double prior_assign, double prob_assign, double prob_not_assign) {
-    double safe_prior_assign = std::max(prior_assign, 1e-99);
-    double inv_prior_assign = 1.0 - safe_prior_assign;
-    double PrDP =
-        prob_assign * safe_prior_assign + prob_not_assign * (1. - prob_assign);
-    double posterior = (prob_assign * (safe_prior_assign / PrDP));
-    double update = (1. + (safe_prior_assign - posterior) / inv_prior_assign);
+  double safe_prior_assign = std::max(prior_assign, 1e-99);
+  double inv_prior_assign = 1.0 - safe_prior_assign;
+  double PrDP =
+      prob_assign * safe_prior_assign + prob_not_assign * (1. - prob_assign);
+  double posterior = (prob_assign * (safe_prior_assign / PrDP));
+  double update = (1. + (safe_prior_assign - posterior) / inv_prior_assign);
 
-    return std::make_tuple(update, posterior);
+  return std::make_tuple(update, posterior);
 }
 
 double BayesianUpdateFunctions::safe_bayesian_update_simple(double prior,
                                                             double likelihood) {
-    double posterior;
-    double safe_prior = std::max(prior, 1e-99);
-    posterior =
-        1. / (1. + ((1. / safe_prior) - 1.) * ((1. - safe_prior) / likelihood));
+  double posterior;
+  double safe_prior = std::max(prior, 1e-99);
+  posterior =
+      1. / (1. + ((1. / safe_prior) - 1.) * ((1. - safe_prior) / likelihood));
 
-    return posterior;
+  return posterior;
 }

--- a/btrack/src/belief.cu
+++ b/btrack/src/belief.cu
@@ -16,23 +16,16 @@
 
 // TODO(arl): Work in Progress...
 
-
 #include "belief.h"
 
-//const float PI_C = 3.141592653589793238463;
+// const float PI_C = 3.141592653589793238463;
 const float ROOT_TWO = 1.4142135623730951;
 
-__device__ float probability_erf_CUDA(const float x,
-                                      const float y,
-                                      const float z,
-                                      const float px,
-                                      const float py,
-                                      const float pz,
-                                      const float var_x,
-                                      const float var_y,
-                                      const float var_z,
-                                      const float accuracy)
-{
+__device__ float probability_erf_CUDA(const float x, const float y,
+                                      const float z, const float px,
+                                      const float py, const float pz,
+                                      const float var_x, const float var_y,
+                                      const float var_z, const float accuracy) {
 
   float phi_x, std_x;
   float phi_y, std_y;
@@ -43,37 +36,30 @@ __device__ float probability_erf_CUDA(const float x,
   std_z = sqrtf(var_z);
 
   // intergral x
-  phi_x = erff((x-px+accuracy) / (std_x*ROOT_TWO)) -
-          erff((x-px-accuracy) / (std_x*ROOT_TWO));
+  phi_x = erff((x - px + accuracy) / (std_x * ROOT_TWO)) -
+          erff((x - px - accuracy) / (std_x * ROOT_TWO));
 
   // intergral y
-  phi_y = erff((y-py+accuracy) / (std_y*ROOT_TWO)) -
-          erff((y-py-accuracy) / (std_y*ROOT_TWO));
+  phi_y = erff((y - py + accuracy) / (std_y * ROOT_TWO)) -
+          erff((y - py - accuracy) / (std_y * ROOT_TWO));
 
   // intergral z
-  phi_z = erff((z-pz+accuracy) / (std_z*ROOT_TWO)) -
-          erff((z-pz-accuracy) / (std_z*ROOT_TWO));
+  phi_z = erff((z - pz + accuracy) / (std_z * ROOT_TWO)) -
+          erff((z - pz - accuracy) / (std_z * ROOT_TWO));
 
   // joint probability
-  float phi = .5*phi_x * .5*phi_y * .5*phi_z;
+  float phi = .5 * phi_x * .5 * phi_y * .5 * phi_z;
 
   // calculate product of integrals for the axes i.e. joint probability?
   return phi;
-
 }
 
-
-
-__global__ void track_CUDA(float* belief_matrix,
-                           const float* new_positions,
-                           const float* predicted_positions,
+__global__ void track_CUDA(float *belief_matrix, const float *new_positions,
+                           const float *predicted_positions,
                            const unsigned int num_obj,
                            const unsigned int num_tracks,
-                           const float prob_not_assign,
-                           const float accuracy)
-{
+                           const float prob_not_assign, const float accuracy) {
   /* perform the acutal tracking association step */
-
 
   // this refers to the active track
   int i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -82,92 +68,90 @@ __global__ void track_CUDA(float* belief_matrix,
   int j = blockIdx.x * blockDim.x + threadIdx.x;
 
   // Don't bother doing the calculation. We're not in a valid location
-  if (i >= num_tracks || j >= num_obj) return;
+  if (i >= num_tracks || j >= num_obj)
+    return;
   // NOTE: we need to update the lost column
 
   // set up the probability for assignment
   float prob_assign = 0.;
 
   // first, get the value of the belief matrix in its current step
-  float prior_assign = belief_matrix[j*num_tracks+i];
+  float prior_assign = belief_matrix[j * num_tracks + i];
 
   float x, y, z, px, py, pz, var_x, var_y, var_z;
 
   // get the new object positions
-  x = new_positions[j*3+0];
-  y = new_positions[j*3+1];
-  z = new_positions[j*3+2];
+  x = new_positions[j * 3 + 0];
+  y = new_positions[j * 3 + 1];
+  z = new_positions[j * 3 + 2];
 
   // get the predictions from the tracks
-  px = predicted_positions[i*6+0];
-  py = predicted_positions[i*6+1];
-  pz = predicted_positions[i*6+2];
-  var_x = predicted_positions[i*6+3];
-  var_y = predicted_positions[i*6+4];
-  var_z = predicted_positions[i*6+5];
+  px = predicted_positions[i * 6 + 0];
+  py = predicted_positions[i * 6 + 1];
+  pz = predicted_positions[i * 6 + 2];
+  var_x = predicted_positions[i * 6 + 3];
+  var_y = predicted_positions[i * 6 + 4];
+  var_z = predicted_positions[i * 6 + 5];
 
   // get the probability of assignment for this track
-  prob_assign = probability_erf_CUDA(x, y, z, px, py, pz, var_x, var_y, var_z, accuracy);
-  float PrDP = prob_assign * prior_assign + prob_not_assign * (1.-prob_assign);
+  prob_assign =
+      probability_erf_CUDA(x, y, z, px, py, pz, var_x, var_y, var_z, accuracy);
+  float PrDP =
+      prob_assign * prior_assign + prob_not_assign * (1. - prob_assign);
   float posterior = (prob_assign * (prior_assign / PrDP));
 
   // update the posterior for this track
-  belief_matrix[j*num_tracks+i] = posterior;
+  belief_matrix[j * num_tracks + i] = posterior;
 
   // make a value which can be updated for all values of this
   float update_value = posterior;
 
   // loop through all of these except for the one we have updated
-  for (int obj=0; obj<num_obj; obj++){
+  for (int obj = 0; obj < num_obj; obj++) {
     if (obj != j) {
 
       // update the belief matrix for all other tracks
-      update_value = update_value * (1. + (prior_assign-posterior)/(1.-prior_assign));
-
+      update_value = update_value *
+                     (1. + (prior_assign - posterior) / (1. - prior_assign));
     }
   }
 
   // update the belief matrix here
-  belief_matrix[j*num_tracks+i] = update_value;
-
+  belief_matrix[j * num_tracks + i] = update_value;
 }
 
-
-
 // This is the interface to the outside world!
-void cost_CUDA(float* belief_matrix,
-               const float* new_positions,
-               const float* predicted_positions,
-               const unsigned int N,
-               const unsigned int T,
-               const float prob_not_assign,
+void cost_CUDA(float *belief_matrix, const float *new_positions,
+               const float *predicted_positions, const unsigned int N,
+               const unsigned int T, const float prob_not_assign,
                const float accuracy) {
-
 
   // allocate some device memory
   float *belief, *new_pos, *pred_pos;
-  cudaMalloc(&belief, N*T*sizeof(float));
-  cudaMalloc(&new_pos, N*sizeof(float));
-  cudaMalloc(&pred_pos, T*sizeof(float));
+  cudaMalloc(&belief, N * T * sizeof(float));
+  cudaMalloc(&new_pos, N * sizeof(float));
+  cudaMalloc(&pred_pos, T * sizeof(float));
 
   // copy to the GPU
-  cudaMemcpy(belief, belief_matrix, N*T*sizeof(float), cudaMemcpyHostToDevice);
-  cudaMemcpy(new_pos, new_positions, N*sizeof(float), cudaMemcpyHostToDevice);
-  cudaMemcpy(pred_pos, predicted_positions, T*sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(belief, belief_matrix, N * T * sizeof(float),
+             cudaMemcpyHostToDevice);
+  cudaMemcpy(new_pos, new_positions, N * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(pred_pos, predicted_positions, T * sizeof(float),
+             cudaMemcpyHostToDevice);
 
   // execute the kernel
-  track_CUDA<<<T,N>>>(belief, new_pos, pred_pos, N, T, prob_not_assign, accuracy);
+  track_CUDA<<<T, N>>>(belief, new_pos, pred_pos, N, T, prob_not_assign,
+                       accuracy);
 
   // get the belief matrix back
-  cudaMemcpy(belief_matrix, belief, N*T*sizeof(float), cudaMemcpyDeviceToHost);
+  cudaMemcpy(belief_matrix, belief, N * T * sizeof(float),
+             cudaMemcpyDeviceToHost);
 
   // clean up
   cudaFree(belief);
   cudaFree(new_pos);
   cudaFree(pred_pos);
 }
-
-
 
 int main_CUDA(void) {
   // do nothing - we'll call this from elsewhere

--- a/btrack/src/hyperbin.cc
+++ b/btrack/src/hyperbin.cc
@@ -97,73 +97,72 @@
 // thus preventing excessive searching over non-local trajectories.
 //
 HypercubeBin::HypercubeBin(void) {
-    // default constructor
+  // default constructor
 }
 
 HypercubeBin::~HypercubeBin(void) {
-    // default destructor
-    m_cube.clear();
+  // default destructor
+  m_cube.clear();
 }
 
 // set up a HashCube with a certain bin size
 HypercubeBin::HypercubeBin(const unsigned int bin_xyz,
                            const unsigned int bin_n) {
-    // default constructor
-    m_bin_size[0] = float(bin_xyz);
-    m_bin_size[1] = float(bin_xyz);
-    m_bin_size[2] = float(bin_xyz);
-    m_bin_size[3] = float(bin_n);
+  // default constructor
+  m_bin_size[0] = float(bin_xyz);
+  m_bin_size[1] = float(bin_xyz);
+  m_bin_size[2] = float(bin_xyz);
+  m_bin_size[3] = float(bin_n);
 }
 
 // use this to calculate the bin of a certain track
 HashIndex HypercubeBin::hash_index(TrackletPtr a_trk,
                                    const bool a_start) const {
-    // get the appropriate object from the track
-    TrackObjectPtr obj;
+  // get the appropriate object from the track
+  TrackObjectPtr obj;
 
-    if (a_start) {
-        obj = a_trk->track.front();
-    } else {
-        obj = a_trk->track.back();
-    }
+  if (a_start) {
+    obj = a_trk->track.front();
+  } else {
+    obj = a_trk->track.back();
+  }
 
-    // return the hash index for this track
-    // return hash_index(obj->x, obj->y, obj->z, obj->t);
-    return hash_index(obj);
+  // return the hash index for this track
+  // return hash_index(obj->x, obj->y, obj->z, obj->t);
+  return hash_index(obj);
 }
 
 HashIndex HypercubeBin::hash_index(const float x, const float y, const float z,
                                    const float n) const {
-    // set up a hash index structure
-    HashIndex idx;
-    idx.x = static_cast<int>(floor((1. / m_bin_size[0]) * x));
-    idx.y = static_cast<int>(floor((1. / m_bin_size[1]) * y));
-    idx.z = static_cast<int>(floor((1. / m_bin_size[2]) * z));
-    idx.n = static_cast<int>(floor((1. / m_bin_size[3]) * n));
-    return idx;
+  // set up a hash index structure
+  HashIndex idx;
+  idx.x = static_cast<int>(floor((1. / m_bin_size[0]) * x));
+  idx.y = static_cast<int>(floor((1. / m_bin_size[1]) * y));
+  idx.z = static_cast<int>(floor((1. / m_bin_size[2]) * z));
+  idx.n = static_cast<int>(floor((1. / m_bin_size[3]) * n));
+  return idx;
 }
 
 // add a track to the hashcube object
 void HypercubeBin::add_tracklet(TrackletPtr a_trk) {
-    // get the index of the start (i.e. first object) of the track
-    add_tracklet(a_trk, true);
+  // get the index of the start (i.e. first object) of the track
+  add_tracklet(a_trk, true);
 }
 
 // add a track to the hashcube object
 void HypercubeBin::add_tracklet(TrackletPtr a_trk, const bool a_start) {
-    // get the index of the start (i.e. first object) of the track?
-    HashIndex idx = hash_index(a_trk, a_start);
+  // get the index of the start (i.e. first object) of the track?
+  HashIndex idx = hash_index(a_trk, a_start);
 
-    // try to insert it
-    std::pair<std::map<HashIndex, std::vector<TrackletPtr>>::iterator, bool>
-        ret;
-    std::vector<TrackletPtr> trk_list = {a_trk};
-    ret = m_cube.emplace(idx, trk_list);
+  // try to insert it
+  std::pair<std::map<HashIndex, std::vector<TrackletPtr>>::iterator, bool> ret;
+  std::vector<TrackletPtr> trk_list = {a_trk};
+  ret = m_cube.emplace(idx, trk_list);
 
-    // if this key already exists, append it to the list
-    if (ret.second == false) {
-        m_cube[idx].push_back(a_trk);
-    }
+  // if this key already exists, append it to the list
+  if (ret.second == false) {
+    m_cube[idx].push_back(a_trk);
+  }
 }
 
 // std::vector<TrackletPtr> HypercubeBin::get(TrackObjectPtr a_obj)
@@ -174,56 +173,56 @@ void HypercubeBin::add_tracklet(TrackletPtr a_trk, const bool a_start) {
 // use this to get the tracks in a certain bin (+/-xyz, but only +n)
 std::vector<TrackletPtr> HypercubeBin::get(const TrackletPtr a_trk,
                                            const bool a_start) {
-    // space for the tracks to be returned
-    std::vector<TrackletPtr> r_trks;
+  // space for the tracks to be returned
+  std::vector<TrackletPtr> r_trks;
 
-    // make a map iterator and search for each of the bins
-    std::map<HashIndex, std::vector<TrackletPtr>>::iterator ret;
+  // make a map iterator and search for each of the bins
+  std::map<HashIndex, std::vector<TrackletPtr>>::iterator ret;
 
-    // get the hash_index (either start or end of trajectory)
-    HashIndex idx = hash_index(a_trk, a_start);
+  // get the hash_index (either start or end of trajectory)
+  HashIndex idx = hash_index(a_trk, a_start);
 
-    // make a bin index structure to interrogate the matrix
-    HashIndex bin_idx;
+  // make a bin index structure to interrogate the matrix
+  HashIndex bin_idx;
 
-    // iterate over time
-    for (int n = idx.n; n <= idx.n + 1; n++) {
-        bin_idx.n = n;
+  // iterate over time
+  for (int n = idx.n; n <= idx.n + 1; n++) {
+    bin_idx.n = n;
 
-        // iterate over z
-        for (int z = idx.z - 1; z <= idx.z + 1; z++) {
-            bin_idx.z = z;
+    // iterate over z
+    for (int z = idx.z - 1; z <= idx.z + 1; z++) {
+      bin_idx.z = z;
 
-            // iterate over y
-            for (int y = idx.y - 1; y <= idx.y + 1; y++) {
-                bin_idx.y = y;
+      // iterate over y
+      for (int y = idx.y - 1; y <= idx.y + 1; y++) {
+        bin_idx.y = y;
 
-                // iterate over x
-                for (int x = idx.x - 1; x <= idx.x + 1; x++) {
-                    bin_idx.x = x;
+        // iterate over x
+        for (int x = idx.x - 1; x <= idx.x + 1; x++) {
+          bin_idx.x = x;
 
-                    // find this bin index and return the list of tracks...
-                    ret = m_cube.find(bin_idx);
+          // find this bin index and return the list of tracks...
+          ret = m_cube.find(bin_idx);
 
-                    // if we didn't find anything...
-                    if (ret == m_cube.end()) continue;
+          // if we didn't find anything...
+          if (ret == m_cube.end())
+            continue;
 
-                    // if we found something, move these into the out queue
-                    for (size_t i = 0; i < ret->second.size(); i++) {
-                        // Note - we need to make sure that the track we return
-                        // doesn't start **BEFORE** the track we're searching
-                        // for....
-                        if (ret->second[i]->track.front()->t >=
-                            a_trk->track.back()->t) {
-                            r_trks.push_back(ret->second[i]);
-                        }
+          // if we found something, move these into the out queue
+          for (size_t i = 0; i < ret->second.size(); i++) {
+            // Note - we need to make sure that the track we return
+            // doesn't start **BEFORE** the track we're searching
+            // for....
+            if (ret->second[i]->track.front()->t >= a_trk->track.back()->t) {
+              r_trks.push_back(ret->second[i]);
+            }
 
-                    }  // i
-                }      // x
-            }          // y
-        }              // z
-    }                  // n
-    return r_trks;
+          } // i
+        }   // x
+      }     // y
+    }       // z
+  }         // n
+  return r_trks;
 }
 
 // A 4D hash cube object.
@@ -232,118 +231,119 @@ std::vector<TrackletPtr> HypercubeBin::get(const TrackletPtr a_trk,
 // thus preventing excessive searching over non-local trajectories.
 //
 ObjectBin::ObjectBin(void) {
-    // default constructor
+  // default constructor
 }
 
 ObjectBin::~ObjectBin(void) {
-    // default destructor
-    m_cube.clear();
+  // default destructor
+  m_cube.clear();
 }
 
 // set up a HashCube with a certain bin size
 ObjectBin::ObjectBin(const unsigned int bin_xyz, const unsigned int bin_n) {
-    // default constructor
-    m_bin_size[0] = float(bin_xyz);
-    m_bin_size[1] = float(bin_xyz);
-    m_bin_size[2] = float(bin_xyz);
-    m_bin_size[3] = float(bin_n);
+  // default constructor
+  m_bin_size[0] = float(bin_xyz);
+  m_bin_size[1] = float(bin_xyz);
+  m_bin_size[2] = float(bin_xyz);
+  m_bin_size[3] = float(bin_n);
 }
 
 // use this to calculate the bin of a certain track
 HashIndex ObjectBin::hash_index(TrackletPtr a_trk, const bool a_start) const {
-    // get the appropriate object from the track
-    TrackObjectPtr obj;
+  // get the appropriate object from the track
+  TrackObjectPtr obj;
 
-    if (a_start) {
-        obj = a_trk->track.front();
-    } else {
-        obj = a_trk->track.back();
-    }
+  if (a_start) {
+    obj = a_trk->track.front();
+  } else {
+    obj = a_trk->track.back();
+  }
 
-    // return the hash index for this track
-    // return hash_index(obj->x, obj->y, obj->z, obj->t);
-    return hash_index(obj);
+  // return the hash index for this track
+  // return hash_index(obj->x, obj->y, obj->z, obj->t);
+  return hash_index(obj);
 }
 
 HashIndex ObjectBin::hash_index(const float x, const float y, const float z,
                                 const float n) const {
-    // set up a hash index structure
-    HashIndex idx;
-    idx.x = static_cast<int>(floor((1. / m_bin_size[0]) * x));
-    idx.y = static_cast<int>(floor((1. / m_bin_size[1]) * y));
-    idx.z = static_cast<int>(floor((1. / m_bin_size[2]) * z));
-    idx.n = 1;  // static_cast<int> ( floor((1./ m_bin_size[3]) * n) );
-    return idx;
+  // set up a hash index structure
+  HashIndex idx;
+  idx.x = static_cast<int>(floor((1. / m_bin_size[0]) * x));
+  idx.y = static_cast<int>(floor((1. / m_bin_size[1]) * y));
+  idx.z = static_cast<int>(floor((1. / m_bin_size[2]) * z));
+  idx.n = 1; // static_cast<int> ( floor((1./ m_bin_size[3]) * n) );
+  return idx;
 }
 
 // add a track to the hashcube object
 void ObjectBin::add_object(TrackObjectPtr a_obj) {
-    // get the index of the start (i.e. first object) of the track?
-    HashIndex idx = hash_index(a_obj);
+  // get the index of the start (i.e. first object) of the track?
+  HashIndex idx = hash_index(a_obj);
 
-    // try to insert it
-    std::pair<
-        std::map<HashIndex, std::vector<TrackObjectPtr_and_Index>>::iterator,
-        bool>
-        ret;
+  // try to insert it
+  std::pair<
+      std::map<HashIndex, std::vector<TrackObjectPtr_and_Index>>::iterator,
+      bool>
+      ret;
 
-    // std::cout << "ObjectBin size: " << n_objects << std::endl;
+  // std::cout << "ObjectBin size: " << n_objects << std::endl;
 
-    std::vector<TrackObjectPtr_and_Index> obj_list = {
-        TrackObjectPtr_and_Index(a_obj, n_objects)};
+  std::vector<TrackObjectPtr_and_Index> obj_list = {
+      TrackObjectPtr_and_Index(a_obj, n_objects)};
 
-    ret = m_cube.emplace(idx, obj_list);
+  ret = m_cube.emplace(idx, obj_list);
 
-    n_objects += 1;
+  n_objects += 1;
 
-    // if this key already exists, append it to the list
-    if (ret.second == false) {
-        m_cube[idx].push_back(obj_list[0]);
-    }
+  // if this key already exists, append it to the list
+  if (ret.second == false) {
+    m_cube[idx].push_back(obj_list[0]);
+  }
 }
 
 // use this to get the tracks in a certain bin (+/-xyz, but only +n)
 std::vector<TrackObjectPtr_and_Index> ObjectBin::get(const TrackletPtr a_trk,
                                                      const bool a_start) {
-    // space for the tracks to be returned
-    std::vector<TrackObjectPtr_and_Index> r_objs;
+  // space for the tracks to be returned
+  std::vector<TrackObjectPtr_and_Index> r_objs;
 
-    // make a map iterator and search for each of the bins
-    std::map<HashIndex, std::vector<TrackObjectPtr_and_Index>>::iterator ret;
+  // make a map iterator and search for each of the bins
+  std::map<HashIndex, std::vector<TrackObjectPtr_and_Index>>::iterator ret;
 
-    // get the hash_index (either start or end of trajectory)
-    HashIndex idx = hash_index(a_trk, a_start);
+  // get the hash_index (either start or end of trajectory)
+  HashIndex idx = hash_index(a_trk, a_start);
 
-    // make a bin index structure to interrogate the matrix
-    HashIndex bin_idx;
+  // make a bin index structure to interrogate the matrix
+  HashIndex bin_idx;
 
-    bin_idx.n = 1;
+  bin_idx.n = 1;
 
-    // iterate over z
-    for (int z = idx.z - 1; z <= idx.z + 1; z++) {
-        bin_idx.z = z;
+  // iterate over z
+  for (int z = idx.z - 1; z <= idx.z + 1; z++) {
+    bin_idx.z = z;
 
-        // iterate over y
-        for (int y = idx.y - 1; y <= idx.y + 1; y++) {
-            bin_idx.y = y;
+    // iterate over y
+    for (int y = idx.y - 1; y <= idx.y + 1; y++) {
+      bin_idx.y = y;
 
-            // iterate over x
-            for (int x = idx.x - 1; x <= idx.x + 1; x++) {
-                bin_idx.x = x;
+      // iterate over x
+      for (int x = idx.x - 1; x <= idx.x + 1; x++) {
+        bin_idx.x = x;
 
-                // find this bin index and return the list of tracks...
-                ret = m_cube.find(bin_idx);
+        // find this bin index and return the list of tracks...
+        ret = m_cube.find(bin_idx);
 
-                // if we didn't find anything...
-                if (ret == m_cube.end()) continue;
+        // if we didn't find anything...
+        if (ret == m_cube.end())
+          continue;
 
-                // if we found something, move these into the out queue
-                for (size_t i = 0; i < ret->second.size(); i++) {
-                    r_objs.push_back(ret->second[i]);
-                }  // i
-            }      // x
-        }          // y
-    }              // z
+        // if we found something, move these into the out queue
+        for (size_t i = 0; i < ret->second.size(); i++) {
+          r_objs.push_back(ret->second[i]);
+        } // i
+      }   // x
+    }     // y
+  }       // z
 
-    return r_objs;
+  return r_objs;
 }

--- a/btrack/src/hypothesis.cc
+++ b/btrack/src/hypothesis.cc
@@ -18,28 +18,29 @@
 
 // safe log function
 double safe_log(double value) {
-    if (value <= 0.) return std::log(DEFAULT_LOW_PROBABILITY);
-    return std::log(value);
+  if (value <= 0.)
+    return std::log(DEFAULT_LOW_PROBABILITY);
+  return std::log(value);
 };
 
 // calculate the Euclidean distance between the end of one track and the
 // beginning of the second track
 double link_distance(const TrackletPtr a_trk, const TrackletPtr a_trk_lnk) {
-    Eigen::Vector3d d =
-        a_trk->track.back()->position() - a_trk_lnk->track.front()->position();
-    return std::sqrt(d.transpose() * d);
+  Eigen::Vector3d d =
+      a_trk->track.back()->position() - a_trk_lnk->track.front()->position();
+  return std::sqrt(d.transpose() * d);
 }
 
 // calculate the Euclidean distance between the end of one track and the
 // beginning of the second track
 double link_time(const TrackletPtr a_trk, const TrackletPtr a_trk_lnk) {
-    return a_trk_lnk->track.front()->t - a_trk->track.back()->t;
+  return a_trk_lnk->track.front()->t - a_trk->track.back()->t;
 }
 
 // count the number of apoptosis events, starting at the terminus of the
 // track
 unsigned int count_apoptosis(const TrackletPtr a_trk) {
-    return count_state_track(a_trk, STATE_apoptosis, COUNT_STATE_FROM_BACK);
+  return count_state_track(a_trk, STATE_apoptosis, COUNT_STATE_FROM_BACK);
 }
 
 // generic state counting from the back/or front of the track
@@ -47,600 +48,594 @@ unsigned int count_apoptosis(const TrackletPtr a_trk) {
 unsigned int count_state_track(const TrackletPtr a_trk,
                                const unsigned int a_state_label,
                                const bool a_from_back) {
-    // check that we have at least one observation in our track
-    assert(a_trk->length() > 0);
+  // check that we have at least one observation in our track
+  assert(a_trk->length() > 0);
 
-    // set the counter, direction and state_counter
-    unsigned int counter;
-    int counter_dir;
-    unsigned int n_state = 0;
+  // set the counter, direction and state_counter
+  unsigned int counter;
+  int counter_dir;
+  unsigned int n_state = 0;
 
-    // if counting from the back, start at the back and reverse the direction
-    if (a_from_back == COUNT_STATE_FROM_BACK) {
-        counter = a_trk->length() - 1;
-        counter_dir = -1;
-    } else {
-        counter = 0;
-        counter_dir = 1;
-    }
+  // if counting from the back, start at the back and reverse the direction
+  if (a_from_back == COUNT_STATE_FROM_BACK) {
+    counter = a_trk->length() - 1;
+    counter_dir = -1;
+  } else {
+    counter = 0;
+    counter_dir = 1;
+  }
 
-    while (a_trk->track[counter]->label == a_state_label && counter >= 0 &&
-           counter < a_trk->length()) {
-        // increment the number of apoptoses
-        n_state++;
-        counter += counter_dir;
+  while (a_trk->track[counter]->label == a_state_label && counter >= 0 &&
+         counter < a_trk->length()) {
+    // increment the number of apoptoses
+    n_state++;
+    counter += counter_dir;
 
-        // immediately exit if we have reached the end
-        if (counter < 0 || counter >= a_trk->length()) break;
-    }
+    // immediately exit if we have reached the end
+    if (counter < 0 || counter >= a_trk->length())
+      break;
+  }
 
-    return n_state;
+  return n_state;
 }
 
 HypothesisEngine::HypothesisEngine(void) {
-    // default constructor
+  // default constructor
 }
 
 HypothesisEngine::HypothesisEngine(const unsigned int a_start_frame,
                                    const unsigned int a_stop_frame,
-                                   const PyHypothesisParams& a_params,
-                                   TrackManager* a_manager) {
-    // m_num_frames = a_stop_frame - a_start_frame;
-    m_frame_range[0] = a_start_frame;
-    m_frame_range[1] = a_stop_frame;
-    m_params = a_params;
+                                   const PyHypothesisParams &a_params,
+                                   TrackManager *a_manager) {
+  // m_num_frames = a_stop_frame - a_start_frame;
+  m_frame_range[0] = a_start_frame;
+  m_frame_range[1] = a_stop_frame;
+  m_params = a_params;
 
-    // store the reference to the manager
-    this->manager = a_manager;
+  // store the reference to the manager
+  this->manager = a_manager;
 
-    // tell the user which hypotheses are going to be created
-    // ['P_FP','P_init','P_term','P_link','P_branch','P_dead','P_merge']
+  // tell the user which hypotheses are going to be created
+  // ['P_FP','P_init','P_term','P_link','P_branch','P_dead','P_merge']
 
-    if (!m_cube.empty()) {
-        std::cout << "Resetting hypothesis engine." << std::endl;
-        reset();
-    }
+  if (!m_cube.empty()) {
+    std::cout << "Resetting hypothesis engine." << std::endl;
+    reset();
+  }
 
-    if (DEBUG) {
-        std::cout << "Hypotheses to generate: " << std::endl;
-        std::cout << " - P_FP: " << hypothesis_allowed(TYPE_Pfalse)
-                  << std::endl;
-        std::cout << " - P_init: " << hypothesis_allowed(TYPE_Pinit)
-                  << std::endl;
-        std::cout << " - P_term: " << hypothesis_allowed(TYPE_Pterm)
-                  << std::endl;
-        std::cout << " - P_link: " << hypothesis_allowed(TYPE_Plink)
-                  << std::endl;
-        std::cout << " - P_branch: " << hypothesis_allowed(TYPE_Pdivn)
-                  << std::endl;
-        std::cout << " - P_dead: " << hypothesis_allowed(TYPE_Papop)
-                  << std::endl;
-        std::cout << " - P_merge: " << hypothesis_allowed(TYPE_Pmrge)
-                  << std::endl;
-    }
+  if (DEBUG) {
+    std::cout << "Hypotheses to generate: " << std::endl;
+    std::cout << " - P_FP: " << hypothesis_allowed(TYPE_Pfalse) << std::endl;
+    std::cout << " - P_init: " << hypothesis_allowed(TYPE_Pinit) << std::endl;
+    std::cout << " - P_term: " << hypothesis_allowed(TYPE_Pterm) << std::endl;
+    std::cout << " - P_link: " << hypothesis_allowed(TYPE_Plink) << std::endl;
+    std::cout << " - P_branch: " << hypothesis_allowed(TYPE_Pdivn) << std::endl;
+    std::cout << " - P_dead: " << hypothesis_allowed(TYPE_Papop) << std::endl;
+    std::cout << " - P_merge: " << hypothesis_allowed(TYPE_Pmrge) << std::endl;
+  }
 
-    // should do some parameter checking here
-    assert(m_params.segmentation_miss_rate >= 0.0 &&
-           m_params.segmentation_miss_rate <= 1.0);
+  // should do some parameter checking here
+  assert(m_params.segmentation_miss_rate >= 0.0 &&
+         m_params.segmentation_miss_rate <= 1.0);
 
-    assert(m_params.apoptosis_rate >= 0.0 && m_params.apoptosis_rate <= 1.0);
+  assert(m_params.apoptosis_rate >= 0.0 && m_params.apoptosis_rate <= 1.0);
 
-    // set up a HashCube
-    m_cube = HypercubeBin(m_params.dist_thresh, m_params.time_thresh);
+  // set up a HashCube
+  m_cube = HypercubeBin(m_params.dist_thresh, m_params.time_thresh);
 }
 
 // reset the engine
 void HypothesisEngine::reset(void) {
-    // clear the tracks and the hashcube
-    // m_tracks.clear();
-    m_cube.clear();
+  // clear the tracks and the hashcube
+  // m_tracks.clear();
+  m_cube.clear();
 }
 
 HypothesisEngine::~HypothesisEngine(void) { reset(); }
 
 void HypothesisEngine::add_track(TrackletPtr a_trk) {
-    // // push this onto the list of trajectories
-    // m_tracks.push_back( a_trk );
+  // // push this onto the list of trajectories
+  // m_tracks.push_back( a_trk );
 
-    // add this one to the hash cube
-    m_cube.add_tracklet(a_trk);
+  // add this one to the hash cube
+  m_cube.add_tracklet(a_trk);
 }
 
 // test whether to generate a certain type of hypothesis
 bool HypothesisEngine::hypothesis_allowed(
     const unsigned int a_hypothesis_type) const {
-    // TODO(arl): make sure that the type exists!
-    unsigned int bitmask = std::pow(2, a_hypothesis_type);
+  // TODO(arl): make sure that the type exists!
+  unsigned int bitmask = std::pow(2, a_hypothesis_type);
 
-    // std::cout << a_hypothesis_type << "," << bitmask << std::endl;
-    if ((m_params.hypotheses_to_generate & bitmask) == bitmask) {
-        return true;
-    }
+  // std::cout << a_hypothesis_type << "," << bitmask << std::endl;
+  if ((m_params.hypotheses_to_generate & bitmask) == bitmask) {
+    return true;
+  }
 
-    return false;
+  return false;
 }
 
 float HypothesisEngine::dist_from_border(TrackletPtr a_trk,
                                          bool a_start) const {
-    // Calculate the distance from the border of the field of view
-    float min_dist, min_this_dim;
-    Eigen::Vector3d xyz;
+  // Calculate the distance from the border of the field of view
+  float min_dist, min_this_dim;
+  Eigen::Vector3d xyz;
 
-    // take either the first or last localisation of the object
-    if (a_start) {
-        xyz = a_trk->track.front()->position();
-    } else {
-        xyz = a_trk->track.back()->position();
+  // take either the first or last localisation of the object
+  if (a_start) {
+    xyz = a_trk->track.front()->position();
+  } else {
+    xyz = a_trk->track.back()->position();
+  }
+
+  // set the distance to infinity
+  min_dist = kInfinity;
+
+  // find the smallest distance between a point and the edge of the volume
+  // NOTE(arl): what if we have zero dimensions?
+  for (unsigned short dim = 0; dim < 3; dim++) {
+    // skip a dimension if it does not exist, for example, in a 2D dataset
+    // all z values will be zero (or at least, the same)
+    if (volume.min_xyz[dim] == volume.max_xyz[dim])
+      continue;
+
+    min_this_dim = std::min(xyz[dim] - volume.min_xyz[dim],
+                            volume.max_xyz[dim] - xyz[dim]);
+
+    if (min_this_dim < min_dist) {
+      min_dist = min_this_dim;
     }
+  }
 
-    // set the distance to infinity
-    min_dist = kInfinity;
-
-    // find the smallest distance between a point and the edge of the volume
-    // NOTE(arl): what if we have zero dimensions?
-    for (unsigned short dim = 0; dim < 3; dim++) {
-        // skip a dimension if it does not exist, for example, in a 2D dataset
-        // all z values will be zero (or at least, the same)
-        if (volume.min_xyz[dim] == volume.max_xyz[dim]) continue;
-
-        min_this_dim = std::min(xyz[dim] - volume.min_xyz[dim],
-                                volume.max_xyz[dim] - xyz[dim]);
-
-        if (min_this_dim < min_dist) {
-            min_dist = min_this_dim;
-        }
-    }
-
-    return min_dist;
+  return min_dist;
 }
 
 // create the hypotheses
 void HypothesisEngine::create(void) {
-    if (manager->num_tracks() < 1) return;
+  if (manager->num_tracks() < 1)
+    return;
 
-    // get the tracks
-    m_num_tracks = manager->num_tracks();
+  // get the tracks
+  m_num_tracks = manager->num_tracks();
 
-    // reserve some memory for the hypotheses (at least 5 times the number of
-    // trajectories)
-    m_hypotheses.clear();
-    m_hypotheses.reserve(m_num_tracks * 5);
+  // reserve some memory for the hypotheses (at least 5 times the number of
+  // trajectories)
+  m_hypotheses.clear();
+  m_hypotheses.reserve(m_num_tracks * 5);
 
-    TrackletPtr trk;
+  TrackletPtr trk;
 
-    // loop through trajectories
-    for (size_t i = 0; i < m_num_tracks; i++) {
-        // PROVIDE SOME DEBUG INFO
-        // if (i % 100 == 0){
-        //   std::cout << "Hypothesis: " << i << " of " << m_num_tracks <<
-        //   std::endl;
-        // }
+  // loop through trajectories
+  for (size_t i = 0; i < m_num_tracks; i++) {
+    // PROVIDE SOME DEBUG INFO
+    // if (i % 100 == 0){
+    //   std::cout << "Hypothesis: " << i << " of " << m_num_tracks <<
+    //   std::endl;
+    // }
 
-        // get the test track
-        trk = manager->get_track(i);
+    // get the test track
+    trk = manager->get_track(i);
 
-        // calculate the false positive hypothesis
-        hypothesis_false_positive(trk);
+    // calculate the false positive hypothesis
+    hypothesis_false_positive(trk);
 
-        // calculate initialization and termination hypotheses
-        hypothesis_init(trk);
-        hypothesis_term(trk);
+    // calculate initialization and termination hypotheses
+    hypothesis_init(trk);
+    hypothesis_term(trk);
 
-        // calculate the death hypotheis
-        hypothesis_dead(trk);
+    // calculate the death hypotheis
+    hypothesis_dead(trk);
 
-        // manage conflicts
-        std::vector<TrackletPtr> conflicts;
+    // manage conflicts
+    std::vector<TrackletPtr> conflicts;
 
-        // iterate over all of the tracks in the hash cube
-        std::vector<TrackletPtr> trks_to_test = m_cube.get(trk, false);
+    // iterate over all of the tracks in the hash cube
+    std::vector<TrackletPtr> trks_to_test = m_cube.get(trk, false);
 
-        for (size_t j = 0; j < trks_to_test.size(); j++) {
-            // get the track
-            TrackletPtr this_trk = trks_to_test[j];
+    for (size_t j = 0; j < trks_to_test.size(); j++) {
+      // get the track
+      TrackletPtr this_trk = trks_to_test[j];
 
-            // make sure we don't check against the same track!
-            if (trk->ID == this_trk->ID) continue;
+      // make sure we don't check against the same track!
+      if (trk->ID == this_trk->ID)
+        continue;
 
-            // calculate the time and distance between this track and the
-            // reference
-            float d = link_distance(trk, this_trk);
-            float dt = link_time(trk, this_trk);
+      // calculate the time and distance between this track and the
+      // reference
+      float d = link_distance(trk, this_trk);
+      float dt = link_time(trk, this_trk);
 
-            // if we exceed these continue
-            if (d > m_params.dist_thresh) continue;
-            if (dt > m_params.time_thresh || dt < 1) continue;  // this was one
+      // if we exceed these continue
+      if (d > m_params.dist_thresh)
+        continue;
+      if (dt > m_params.time_thresh || dt < 1)
+        continue; // this was one
 
-            // calculate the linkage hypothesis
-            hypothesis_link(trk, this_trk);
+      // calculate the linkage hypothesis
+      hypothesis_link(trk, this_trk);
 
-            // append this to conflicts
-            conflicts.push_back(this_trk);
+      // append this to conflicts
+      conflicts.push_back(this_trk);
 
-        }  // j
+    } // j
 
-        // if we have conflicts, this may mean divisions have occurred
-        if (conflicts.size() < 2) continue;
+    // if we have conflicts, this may mean divisions have occurred
+    if (conflicts.size() < 2)
+      continue;
 
-        // std::cout << "Conflicts: " << conflicts.size() << std::endl;
+    // std::cout << "Conflicts: " << conflicts.size() << std::endl;
 
-        // iterate through the conflicts and put division hypotheses into the
-        // list, including links to the children
-        for (unsigned int p = 0; p < conflicts.size() - 1; p++) {
-            // get the first putative child
-            TrackletPtr trk_c0 = conflicts[p];
+    // iterate through the conflicts and put division hypotheses into the
+    // list, including links to the children
+    for (unsigned int p = 0; p < conflicts.size() - 1; p++) {
+      // get the first putative child
+      TrackletPtr trk_c0 = conflicts[p];
 
-            for (unsigned int q = p + 1; q < conflicts.size(); q++) {
-                // get the second putative child
-                TrackletPtr trk_c1 = conflicts[q];
+      for (unsigned int q = p + 1; q < conflicts.size(); q++) {
+        // get the second putative child
+        TrackletPtr trk_c1 = conflicts[q];
 
-                // calculate the division hypothesis
-                hypothesis_branch(trk, trk_c0, trk_c1);
+        // calculate the division hypothesis
+        hypothesis_branch(trk, trk_c0, trk_c1);
 
-                // std::cout << trk->ID << " --> [" << trk_c0->ID << ", " <<
-                // trk_c1->ID << "]" << std::endl; std::cout <<
-                // link_distance(trk, trk_c0) << " - " << link_distance(trk,
-                // trk_c1) << std::endl;
+        // std::cout << trk->ID << " --> [" << trk_c0->ID << ", " <<
+        // trk_c1->ID << "]" << std::endl; std::cout <<
+        // link_distance(trk, trk_c0) << " - " << link_distance(trk,
+        // trk_c1) << std::endl;
 
-            }  // q
-        }      // p
-    }
+      } // q
+    }   // p
+  }
 }
 
 // HYPOTHESES
 void HypothesisEngine::hypothesis_false_positive(TrackletPtr a_trk) {
-    // false positive hypothesis calculated for everything
-    Hypothesis h_fp(TYPE_Pfalse, a_trk);
-    h_fp.probability = safe_log(P_FP(a_trk));
-    m_hypotheses.push_back(h_fp);
+  // false positive hypothesis calculated for everything
+  Hypothesis h_fp(TYPE_Pfalse, a_trk);
+  h_fp.probability = safe_log(P_FP(a_trk));
+  m_hypotheses.push_back(h_fp);
 }
 
 void HypothesisEngine::hypothesis_init(TrackletPtr a_trk) {
-    // distance from the frame border
-    float d_start = dist_from_border(a_trk, true);
-    // float d_stop = dist_from_border( trk, false );
+  // distance from the frame border
+  float d_start = dist_from_border(a_trk, true);
+  // float d_stop = dist_from_border( trk, false );
 
-    // now calculate the initialisation
-    if (hypothesis_allowed(TYPE_Pinit)) {
-        if (m_params.relax ||
-            a_trk->track.front()->t < m_frame_range[0] + m_params.theta_time ||
-            d_start < m_params.theta_dist) {
-            // calculate the probabilities
-            double prob_init_border = P_init_border(a_trk);
-            double prob_init_front = P_init_front(a_trk);
+  // now calculate the initialisation
+  if (hypothesis_allowed(TYPE_Pinit)) {
+    if (m_params.relax ||
+        a_trk->track.front()->t < m_frame_range[0] + m_params.theta_time ||
+        d_start < m_params.theta_dist) {
+      // calculate the probabilities
+      double prob_init_border = P_init_border(a_trk);
+      double prob_init_front = P_init_front(a_trk);
 
-            // take the highest likelihood hypothesis
-            // double prob_init = std::max(prob_init_border, prob_init_front);
-            // short int best_hypothesis = std::argmax(prob_init_border,
-            // prob_init_front);
+      // take the highest likelihood hypothesis
+      // double prob_init = std::max(prob_init_border, prob_init_front);
+      // short int best_hypothesis = std::argmax(prob_init_border,
+      // prob_init_front);
 
-            // assign the correct initialization hypothesis type
-            unsigned int h_init_type;
+      // assign the correct initialization hypothesis type
+      unsigned int h_init_type;
 
-            if (prob_init_border > prob_init_front) {
-                // if the border is the highest probability, but we have
-                // exceeded the threshold, then label this as a lazy
-                // initialization, which should only occur if using the 'relax'
-                // mode.
+      if (prob_init_border > prob_init_front) {
+        // if the border is the highest probability, but we have
+        // exceeded the threshold, then label this as a lazy
+        // initialization, which should only occur if using the 'relax'
+        // mode.
 
-                if (d_start >= m_params.theta_dist) {
-                    h_init_type = TYPE_Pinit_lazy;
-                } else {
-                    h_init_type = TYPE_Pinit_border;
-                }
-
-                Hypothesis h_init(h_init_type, a_trk);
-                h_init.probability =
-                    safe_log(prob_init_border) + 0.5 * safe_log(P_TP(a_trk));
-                m_hypotheses.push_back(h_init);
-                return;
-
-            } else {
-                // if the front is the highest probability, but we have exceeded
-                // the threshold, then label this as a lazy initialization,
-                // which should only occur if using the 'relax' mode.
-
-                if (a_trk->track.front()->t >=
-                    m_frame_range[0] + m_params.theta_time) {
-                    h_init_type = TYPE_Pinit_lazy;
-                } else {
-                    h_init_type = TYPE_Pinit_front;
-                }
-
-                Hypothesis h_init(h_init_type, a_trk);
-                h_init.probability =
-                    safe_log(prob_init_front) + 0.5 * safe_log(P_TP(a_trk));
-                m_hypotheses.push_back(h_init);
-                return;
-            }
+        if (d_start >= m_params.theta_dist) {
+          h_init_type = TYPE_Pinit_lazy;
+        } else {
+          h_init_type = TYPE_Pinit_border;
         }
+
+        Hypothesis h_init(h_init_type, a_trk);
+        h_init.probability =
+            safe_log(prob_init_border) + 0.5 * safe_log(P_TP(a_trk));
+        m_hypotheses.push_back(h_init);
+        return;
+
+      } else {
+        // if the front is the highest probability, but we have exceeded
+        // the threshold, then label this as a lazy initialization,
+        // which should only occur if using the 'relax' mode.
+
+        if (a_trk->track.front()->t >= m_frame_range[0] + m_params.theta_time) {
+          h_init_type = TYPE_Pinit_lazy;
+        } else {
+          h_init_type = TYPE_Pinit_front;
+        }
+
+        Hypothesis h_init(h_init_type, a_trk);
+        h_init.probability =
+            safe_log(prob_init_front) + 0.5 * safe_log(P_TP(a_trk));
+        m_hypotheses.push_back(h_init);
+        return;
+      }
     }
+  }
 }
 
 void HypothesisEngine::hypothesis_term(TrackletPtr a_trk) {
-    // Probability of termination event.  Similar to initialisation, except that
-    // we use the final location/time of the tracklet.
+  // Probability of termination event.  Similar to initialisation, except that
+  // we use the final location/time of the tracklet.
 
-    // distance from the frame border
-    // float d_start = dist_from_border( a_trk, true );
-    float d_stop = dist_from_border(a_trk, false);
+  // distance from the frame border
+  // float d_start = dist_from_border( a_trk, true );
+  float d_stop = dist_from_border(a_trk, false);
 
-    // now calculate the termination
-    if (hypothesis_allowed(TYPE_Pterm)) {
-        if (m_params.relax ||
-            a_trk->track.back()->t > m_frame_range[1] - m_params.theta_time ||
-            d_stop < m_params.theta_dist) {
-            // calculate the probabilities
-            double prob_term_border = P_term_border(a_trk);
-            double prob_term_back = P_term_back(a_trk);
+  // now calculate the termination
+  if (hypothesis_allowed(TYPE_Pterm)) {
+    if (m_params.relax ||
+        a_trk->track.back()->t > m_frame_range[1] - m_params.theta_time ||
+        d_stop < m_params.theta_dist) {
+      // calculate the probabilities
+      double prob_term_border = P_term_border(a_trk);
+      double prob_term_back = P_term_back(a_trk);
 
-            // take the highest likelihood hypothesis
-            // double prob_term = std::max(prob_term_border, prob_term_back);
+      // take the highest likelihood hypothesis
+      // double prob_term = std::max(prob_term_border, prob_term_back);
 
-            // assign the correct initialization hypothesis type
-            unsigned int h_term_type;
+      // assign the correct initialization hypothesis type
+      unsigned int h_term_type;
 
-            if (prob_term_border > prob_term_back) {
-                // if the border is the highest probability, but we have
-                // exceeded the threshold, then label this as a lazy
-                // termination, which should only occur if using the 'relax'
-                // mode.
+      if (prob_term_border > prob_term_back) {
+        // if the border is the highest probability, but we have
+        // exceeded the threshold, then label this as a lazy
+        // termination, which should only occur if using the 'relax'
+        // mode.
 
-                if (d_stop >= m_params.theta_dist) {
-                    h_term_type = TYPE_Pterm_lazy;
-                } else {
-                    h_term_type = TYPE_Pterm_border;
-                }
-
-                Hypothesis h_term(h_term_type, a_trk);
-                h_term.probability =
-                    safe_log(prob_term_border) + 0.5 * safe_log(P_TP(a_trk));
-                m_hypotheses.push_back(h_term);
-                return;
-
-            } else {
-                // if the back is the highest probability, but we have exceeded
-                // the threshold, then label this as a lazy termination, which
-                // should only occur if using the 'relax' mode.
-
-                if (a_trk->track.back()->t <=
-                    m_frame_range[1] - m_params.theta_time) {
-                    h_term_type = TYPE_Pterm_lazy;
-                } else {
-                    h_term_type = TYPE_Pterm_back;
-                }
-
-                Hypothesis h_term(h_term_type, a_trk);
-                h_term.probability =
-                    safe_log(prob_term_back) + 0.5 * safe_log(P_TP(a_trk));
-                m_hypotheses.push_back(h_term);
-                return;
-            }
+        if (d_stop >= m_params.theta_dist) {
+          h_term_type = TYPE_Pterm_lazy;
+        } else {
+          h_term_type = TYPE_Pterm_border;
         }
+
+        Hypothesis h_term(h_term_type, a_trk);
+        h_term.probability =
+            safe_log(prob_term_border) + 0.5 * safe_log(P_TP(a_trk));
+        m_hypotheses.push_back(h_term);
+        return;
+
+      } else {
+        // if the back is the highest probability, but we have exceeded
+        // the threshold, then label this as a lazy termination, which
+        // should only occur if using the 'relax' mode.
+
+        if (a_trk->track.back()->t <= m_frame_range[1] - m_params.theta_time) {
+          h_term_type = TYPE_Pterm_lazy;
+        } else {
+          h_term_type = TYPE_Pterm_back;
+        }
+
+        Hypothesis h_term(h_term_type, a_trk);
+        h_term.probability =
+            safe_log(prob_term_back) + 0.5 * safe_log(P_TP(a_trk));
+        m_hypotheses.push_back(h_term);
+        return;
+      }
     }
+  }
 }
 
 void HypothesisEngine::hypothesis_dead(TrackletPtr a_trk) {
-    // NEW apoptosis detection hypothesis
-    unsigned int n_apoptosis = count_apoptosis(a_trk);
+  // NEW apoptosis detection hypothesis
+  unsigned int n_apoptosis = count_apoptosis(a_trk);
 
-    if (hypothesis_allowed(TYPE_Papop) && n_apoptosis >= m_params.apop_thresh) {
-        Hypothesis h_apoptosis(TYPE_Papop, a_trk);
-        h_apoptosis.probability =
-            safe_log(P_dead(a_trk, n_apoptosis)) + 0.5 * safe_log(P_TP(a_trk));
-        m_hypotheses.push_back(h_apoptosis);
-    }
+  if (hypothesis_allowed(TYPE_Papop) && n_apoptosis >= m_params.apop_thresh) {
+    Hypothesis h_apoptosis(TYPE_Papop, a_trk);
+    h_apoptosis.probability =
+        safe_log(P_dead(a_trk, n_apoptosis)) + 0.5 * safe_log(P_TP(a_trk));
+    m_hypotheses.push_back(h_apoptosis);
+  }
 }
 
 void HypothesisEngine::hypothesis_link(TrackletPtr a_trk,
                                        TrackletPtr a_trk_lnk) {
-    if (hypothesis_allowed(TYPE_Plink)) {
-        // calculate distances in space and time
-        float d = link_distance(a_trk, a_trk_lnk);
-        float dt = link_time(a_trk, a_trk_lnk);
+  if (hypothesis_allowed(TYPE_Plink)) {
+    // calculate distances in space and time
+    float d = link_distance(a_trk, a_trk_lnk);
+    float dt = link_time(a_trk, a_trk_lnk);
 
-        // if (trk->track.back()->label == STATE_metaphase &&
-        //     this_trk->track.front()->label == STATE_anaphase &&
-        //     DISALLOW_METAPHASE_ANAPHASE_LINKING) {
-        //       // do nothing
-        // } else {
+    // if (trk->track.back()->label == STATE_metaphase &&
+    //     this_trk->track.front()->label == STATE_anaphase &&
+    //     DISALLOW_METAPHASE_ANAPHASE_LINKING) {
+    //       // do nothing
+    // } else {
 
-        // if we allow this link, make the hypothesis
-        Hypothesis h_link(TYPE_Plink, a_trk);
-        h_link.trk_link_ID = a_trk_lnk;
-        h_link.probability = safe_log(P_link(a_trk, a_trk_lnk, d, dt)) +
-                             0.5 * safe_log(P_TP(a_trk)) +
-                             0.5 * safe_log(P_TP(a_trk_lnk));
-        m_hypotheses.push_back(h_link);
+    // if we allow this link, make the hypothesis
+    Hypothesis h_link(TYPE_Plink, a_trk);
+    h_link.trk_link_ID = a_trk_lnk;
+    h_link.probability = safe_log(P_link(a_trk, a_trk_lnk, d, dt)) +
+                         0.5 * safe_log(P_TP(a_trk)) +
+                         0.5 * safe_log(P_TP(a_trk_lnk));
+    m_hypotheses.push_back(h_link);
 
-        if (manager->get_store_candidate_graph()) {
-            manager->push_edge(a_trk->track.back(), a_trk_lnk->track.front(),
-                               std::exp(h_link.probability),
-                               GRAPH_EDGE_hyperlink);
-        }
-
-        // }
+    if (manager->get_store_candidate_graph()) {
+      manager->push_edge(a_trk->track.back(), a_trk_lnk->track.front(),
+                         std::exp(h_link.probability), GRAPH_EDGE_hyperlink);
     }
+
+    // }
+  }
 }
 
 void HypothesisEngine::hypothesis_branch(TrackletPtr a_trk,
                                          TrackletPtr a_trk_c0,
                                          TrackletPtr a_trk_c1) {
-    if (hypothesis_allowed(TYPE_Pdivn)) {
-        Hypothesis h_divn(TYPE_Pdivn, a_trk);
-        h_divn.trk_child_one_ID = a_trk_c0;
-        h_divn.trk_child_two_ID = a_trk_c1;
-        h_divn.probability = safe_log(P_branch(a_trk, a_trk_c0, a_trk_c1)) +
-                             0.5 * safe_log(P_TP(a_trk)) +
-                             0.5 * safe_log(P_TP(a_trk_c0)) +
-                             0.5 * safe_log(P_TP(a_trk_c1));
-        m_hypotheses.push_back(h_divn);
+  if (hypothesis_allowed(TYPE_Pdivn)) {
+    Hypothesis h_divn(TYPE_Pdivn, a_trk);
+    h_divn.trk_child_one_ID = a_trk_c0;
+    h_divn.trk_child_two_ID = a_trk_c1;
+    h_divn.probability = safe_log(P_branch(a_trk, a_trk_c0, a_trk_c1)) +
+                         0.5 * safe_log(P_TP(a_trk)) +
+                         0.5 * safe_log(P_TP(a_trk_c0)) +
+                         0.5 * safe_log(P_TP(a_trk_c1));
+    m_hypotheses.push_back(h_divn);
 
-        if (manager->get_store_candidate_graph()) {
-            manager->push_edge(a_trk->track.back(), a_trk_c0->track.front(),
-                               std::exp(h_divn.probability),
-                               GRAPH_EDGE_hyperlink);
-            manager->push_edge(a_trk->track.back(), a_trk_c1->track.front(),
-                               std::exp(h_divn.probability),
-                               GRAPH_EDGE_hyperlink);
-        }
+    if (manager->get_store_candidate_graph()) {
+      manager->push_edge(a_trk->track.back(), a_trk_c0->track.front(),
+                         std::exp(h_divn.probability), GRAPH_EDGE_hyperlink);
+      manager->push_edge(a_trk->track.back(), a_trk_c1->track.front(),
+                         std::exp(h_divn.probability), GRAPH_EDGE_hyperlink);
     }
+  }
 }
 
 // FALSE POSITIVE HYPOTHESIS
 double HypothesisEngine::P_FP(TrackletPtr a_trk) const {
-    unsigned int len_track = static_cast<unsigned int>(1. + a_trk->duration());
-    return std::pow(m_params.segmentation_miss_rate, len_track);
+  unsigned int len_track = static_cast<unsigned int>(1. + a_trk->duration());
+  return std::pow(m_params.segmentation_miss_rate, len_track);
 }
 
 // TRUE POSITIVE HYPOTHESIS
 double HypothesisEngine::P_TP(TrackletPtr a_trk) const {
-    return 1.0 - P_FP(a_trk);
+  return 1.0 - P_FP(a_trk);
 }
 
 // INITIALIZATION HYPOTHESES
 double HypothesisEngine::P_init_border(TrackletPtr a_trk) const {
-    float dist = dist_from_border(a_trk, true);
+  float dist = dist_from_border(a_trk, true);
 
-    // NOTE(arl): if we have 'relax' on, then this hypothesis will be generated
-    // regardless of whether the cell is at the periphery of the FOV or not.
-    // Therefore, we should clamp the distance to the maximum value, so as not
-    // to penalize cells at the centre of the FOV
-    dist = std::min(dist, static_cast<float>(m_params.theta_dist));
+  // NOTE(arl): if we have 'relax' on, then this hypothesis will be generated
+  // regardless of whether the cell is at the periphery of the FOV or not.
+  // Therefore, we should clamp the distance to the maximum value, so as not
+  // to penalize cells at the centre of the FOV
+  dist = std::min(dist, static_cast<float>(m_params.theta_dist));
 
-    if (dist < m_params.theta_dist || m_params.relax) {
-        return std::exp(-dist / m_params.lambda_dist);
-    } else {
-        return m_params.eta;
-    }
+  if (dist < m_params.theta_dist || m_params.relax) {
+    return std::exp(-dist / m_params.lambda_dist);
+  } else {
+    return m_params.eta;
+  }
 }
 
 double HypothesisEngine::P_init_front(TrackletPtr a_trk) const {
-    if (a_trk->track.front()->t < m_frame_range[0] + m_params.theta_time) {
-        return std::exp(
-            -(a_trk->track.front()->t - (float)m_frame_range[0] + 1.0) /
-            m_params.lambda_time);
-    } else {
-        return m_params.eta;
-    }
+  if (a_trk->track.front()->t < m_frame_range[0] + m_params.theta_time) {
+    return std::exp(-(a_trk->track.front()->t - (float)m_frame_range[0] + 1.0) /
+                    m_params.lambda_time);
+  } else {
+    return m_params.eta;
+  }
 }
 
 // TERMINATION HYPOTHESIS
 double HypothesisEngine::P_term_border(TrackletPtr a_trk) const {
-    float dist = dist_from_border(a_trk, false);
+  float dist = dist_from_border(a_trk, false);
 
-    // NOTE(arl): if we have 'relax' on, then this hypothesis will be generated
-    // regardless of whether the cell is at the periphery of the FOV or not.
-    // Therefore, we should clamp the distance to the maximum value, so as not
-    // to penalize cells at the centre of the FOV
-    dist = std::min(dist, static_cast<float>(m_params.theta_dist));
+  // NOTE(arl): if we have 'relax' on, then this hypothesis will be generated
+  // regardless of whether the cell is at the periphery of the FOV or not.
+  // Therefore, we should clamp the distance to the maximum value, so as not
+  // to penalize cells at the centre of the FOV
+  dist = std::min(dist, static_cast<float>(m_params.theta_dist));
 
-    if (dist < m_params.theta_dist || m_params.relax) {
-        return std::exp(-dist / m_params.lambda_dist);
-    } else {
-        return m_params.eta;
-    }
+  if (dist < m_params.theta_dist || m_params.relax) {
+    return std::exp(-dist / m_params.lambda_dist);
+  } else {
+    return m_params.eta;
+  }
 }
 
 double HypothesisEngine::P_term_back(TrackletPtr a_trk) const {
-    if (m_frame_range[1] - a_trk->track.back()->t < m_params.theta_time) {
-        return std::exp(-((float)m_frame_range[1] - a_trk->track.back()->t) /
-                        m_params.lambda_time);
-    } else {
-        return m_params.eta;
-    }
+  if (m_frame_range[1] - a_trk->track.back()->t < m_params.theta_time) {
+    return std::exp(-((float)m_frame_range[1] - a_trk->track.back()->t) /
+                    m_params.lambda_time);
+  } else {
+    return m_params.eta;
+  }
 }
 
 // EXTRUSION HYPOTHESIS
 double HypothesisEngine::P_extrude(TrackletPtr a_trk) const {
-    // Probability of an extrusion event, similar to a termination event.
-    // TODO(arl): implement this
-    return m_params.eta;
+  // Probability of an extrusion event, similar to a termination event.
+  // TODO(arl): implement this
+  return m_params.eta;
 }
 
 // APOPTOSIS HYPOTHESIS
 double HypothesisEngine::P_dead(TrackletPtr a_trk,
                                 const unsigned int n_apoptosis) const {
-    // want to discount this by how close it is to the border of the field of
-    // view - this is to make sure this is a genuine apoptosis and not just a
-    // track leaving the field of view
+  // want to discount this by how close it is to the border of the field of
+  // view - this is to make sure this is a genuine apoptosis and not just a
+  // track leaving the field of view
 
-    // float dist = dist_from_border(a_trk, false);
-    // float discount = 1.0 - std::exp(-dist/m_params.lambda_dist);
-    float discount = 1.0;
+  // float dist = dist_from_border(a_trk, false);
+  // float discount = 1.0 - std::exp(-dist/m_params.lambda_dist);
+  float discount = 1.0;
 
-    // TODO(arl): rather than calculate the probability as the number of
-    // apoptotic observations, perhaps the fraction of the track length that is
-    // apoptotic is more appropriate?
+  // TODO(arl): rather than calculate the probability as the number of
+  // apoptotic observations, perhaps the fraction of the track length that is
+  // apoptotic is more appropriate?
 
-    float p_apoptosis = 0.;
+  float p_apoptosis = 0.;
 
-    if (USE_ABSOLUTE_APOPTOSIS_COUNTS) {
-        p_apoptosis = 1.0 - std::pow(m_params.apoptosis_rate, n_apoptosis);
-    } else {
-        p_apoptosis = static_cast<float>(n_apoptosis) /
-                      static_cast<float>(a_trk->length());
-    }
+  if (USE_ABSOLUTE_APOPTOSIS_COUNTS) {
+    p_apoptosis = 1.0 - std::pow(m_params.apoptosis_rate, n_apoptosis);
+  } else {
+    p_apoptosis =
+        static_cast<float>(n_apoptosis) / static_cast<float>(a_trk->length());
+  }
 
-    // sanity check
-    assert(p_apoptosis >= 0. && p_apoptosis <= 1.);
+  // sanity check
+  assert(p_apoptosis >= 0. && p_apoptosis <= 1.);
 
-    return p_apoptosis * discount;
+  return p_apoptosis * discount;
 }
 
 double HypothesisEngine::P_dead(TrackletPtr a_trk) const {
-    unsigned int n_apoptosis = count_apoptosis(a_trk);
-    return P_dead(a_trk, n_apoptosis);
+  unsigned int n_apoptosis = count_apoptosis(a_trk);
+  return P_dead(a_trk, n_apoptosis);
 }
 
 // LINKING HYPOTHESIS
 double HypothesisEngine::P_link(TrackletPtr a_trk,
                                 TrackletPtr a_trk_lnk) const {
-    float d = link_distance(a_trk, a_trk_lnk);
-    float dt = link_time(a_trk, a_trk_lnk);
+  float d = link_distance(a_trk, a_trk_lnk);
+  float dt = link_time(a_trk, a_trk_lnk);
 
-    // return the full version output
-    return P_link(a_trk, a_trk_lnk, d, dt);
+  // return the full version output
+  return P_link(a_trk, a_trk_lnk, d, dt);
 }
 
 double HypothesisEngine::P_link(TrackletPtr a_trk, TrackletPtr a_trk_lnk,
                                 float d, float dt) const {
-    // make sure that we're looking forward in time, this should never be needed
-    assert(dt > 0.0);
+  // make sure that we're looking forward in time, this should never be needed
+  assert(dt > 0.0);
 
-    // // try to not link metaphase to anaphase
-    // if (DISALLOW_METAPHASE_ANAPHASE_LINKING) {
-    //   if (a_trk->track.back()->label == STATE_metaphase &&
-    //       a_trk_lnk->track.front()->label == STATE_anaphase) {
-    //
-    //     std::cout << a_trk->ID << " -> " << a_trk_lnk->ID << " forbidden
-    //     M->A" << std::endl; return m_params.eta;
-    //   }
-    // }
+  // // try to not link metaphase to anaphase
+  // if (DISALLOW_METAPHASE_ANAPHASE_LINKING) {
+  //   if (a_trk->track.back()->label == STATE_metaphase &&
+  //       a_trk_lnk->track.front()->label == STATE_anaphase) {
+  //
+  //     std::cout << a_trk->ID << " -> " << a_trk_lnk->ID << " forbidden
+  //     M->A" << std::endl; return m_params.eta;
+  //   }
+  // }
 
-    float link_penalty = 1.0;
+  float link_penalty = 1.0;
 
-    // try to not link metaphase to anaphase
-    if (DISALLOW_METAPHASE_ANAPHASE_LINKING) {
-        if (a_trk->track.back()->label == STATE_metaphase &&
-            a_trk_lnk->track.front()->label == STATE_anaphase) {
-            link_penalty = PENALTY_METAPHASE_ANAPHASE_LINKING;
-        }
+  // try to not link metaphase to anaphase
+  if (DISALLOW_METAPHASE_ANAPHASE_LINKING) {
+    if (a_trk->track.back()->label == STATE_metaphase &&
+        a_trk_lnk->track.front()->label == STATE_anaphase) {
+      link_penalty = PENALTY_METAPHASE_ANAPHASE_LINKING;
     }
+  }
 
-    // disallow incorrect linking
-    if (DISALLOW_PROMETAPHASE_ANAPHASE_LINKING) {
-        if (a_trk->track.back()->label == STATE_prometaphase &&
-            a_trk_lnk->track.front()->label == STATE_anaphase) {
-            // set the probability of assignment to zero
-            link_penalty = PENALTY_METAPHASE_ANAPHASE_LINKING;
-        }
+  // disallow incorrect linking
+  if (DISALLOW_PROMETAPHASE_ANAPHASE_LINKING) {
+    if (a_trk->track.back()->label == STATE_prometaphase &&
+        a_trk_lnk->track.front()->label == STATE_anaphase) {
+      // set the probability of assignment to zero
+      link_penalty = PENALTY_METAPHASE_ANAPHASE_LINKING;
     }
+  }
 
-    // DONE(arl): need to penalise longer times between tracks, dt acts as
-    // a linear scaling penalty - scale the distance linearly by time
-    // return std::exp(-(d*dt)/m_params.lambda_link);
-    return std::exp(-(d * link_penalty) / m_params.lambda_link);
+  // DONE(arl): need to penalise longer times between tracks, dt acts as
+  // a linear scaling penalty - scale the distance linearly by time
+  // return std::exp(-(d*dt)/m_params.lambda_link);
+  return std::exp(-(d * link_penalty) / m_params.lambda_link);
 }
 
 // DIVISION HYPOTHESIS
@@ -662,65 +657,62 @@ double HypothesisEngine::P_link(TrackletPtr a_trk, TrackletPtr a_trk_lnk,
 
 double HypothesisEngine::P_branch(TrackletPtr a_trk, TrackletPtr a_trk_c0,
                                   TrackletPtr a_trk_c1) const {
-    // calculate the distance between the previous observation and both of the
-    // putative children these are the normalising factors for the dot product
-    // a dot product < 0 would indicate that the cells are aligned with the
-    // metaphase phase i.e. a good division
-    Eigen::Vector3d d_c0, d_c1;
-    d_c0 =
-        a_trk_c0->track.front()->position() - a_trk->track.back()->position();
-    d_c1 =
-        a_trk_c1->track.front()->position() - a_trk->track.back()->position();
+  // calculate the distance between the previous observation and both of the
+  // putative children these are the normalising factors for the dot product
+  // a dot product < 0 would indicate that the cells are aligned with the
+  // metaphase phase i.e. a good division
+  Eigen::Vector3d d_c0, d_c1;
+  d_c0 = a_trk_c0->track.front()->position() - a_trk->track.back()->position();
+  d_c1 = a_trk_c1->track.front()->position() - a_trk->track.back()->position();
 
-    // normalise the vectors to calculate the dot product
-    double dot_product = d_c0.normalized().transpose() * d_c1.normalized();
+  // normalise the vectors to calculate the dot product
+  double dot_product = d_c0.normalized().transpose() * d_c1.normalized();
 
-    // initialise variables
-    double daughter_angle;
-    double weight;
+  // initialise variables
+  double daughter_angle;
+  double weight;
 
-    // parent is metaphase
-    if (a_trk->track.back()->label == STATE_metaphase) {
-        if (a_trk_c0->track.front()->label == STATE_anaphase &&
-            a_trk_c1->track.front()->label == STATE_anaphase) {
-            // BEST
-            weight = WEIGHT_METAPHASE_ANAPHASE_ANAPHASE;
-        } else if (a_trk_c0->track.front()->label == STATE_anaphase ||
-                   a_trk_c1->track.front()->label == STATE_anaphase) {
-            // PRETTY GOOD
-            weight = WEIGHT_METAPHASE_ANAPHASE;
-        } else {
-            // OK
-            weight = WEIGHT_METAPHASE;
-        }
-
-        // parent is not metaphase
+  // parent is metaphase
+  if (a_trk->track.back()->label == STATE_metaphase) {
+    if (a_trk_c0->track.front()->label == STATE_anaphase &&
+        a_trk_c1->track.front()->label == STATE_anaphase) {
+      // BEST
+      weight = WEIGHT_METAPHASE_ANAPHASE_ANAPHASE;
+    } else if (a_trk_c0->track.front()->label == STATE_anaphase ||
+               a_trk_c1->track.front()->label == STATE_anaphase) {
+      // PRETTY GOOD
+      weight = WEIGHT_METAPHASE_ANAPHASE;
     } else {
-        if (a_trk_c0->track.front()->label == STATE_anaphase &&
-            a_trk_c1->track.front()->label == STATE_anaphase) {
-            // PRETTY GOOD
-            weight = WEIGHT_ANAPHASE_ANAPHASE;
-        } else if (a_trk_c0->track.front()->label == STATE_anaphase ||
-                   a_trk_c1->track.front()->label == STATE_anaphase) {
-            // OK
-            weight = WEIGHT_ANAPHASE;
-        } else {
-            // in this case, none of the criteria are satisfied
-            weight =
-                WEIGHT_OTHER + 10. * P_dead(a_trk_c0) + 10. * P_dead(a_trk_c1);
-
-            // return here if none of the criteria are satisfied
-            return std::exp(-weight / (2. * m_params.lambda_branch));
-        }
+      // OK
+      weight = WEIGHT_METAPHASE;
     }
 
-    // weighted angle between the daughter cells and the parent
-    // use an erf as the weighting function
-    // dot product scales between -1 (ideal) where the daughters are on opposite
-    // sides of the parent, to 1, where the daughters are close in space on the
-    // same side (worst case). Error function will scale these from ~0. to ~1.
-    // meaning that the ideal case minimises the weight
-    daughter_angle = 1.0 - ((1. - std::erf(dot_product * 3.)) / 2.0);
+    // parent is not metaphase
+  } else {
+    if (a_trk_c0->track.front()->label == STATE_anaphase &&
+        a_trk_c1->track.front()->label == STATE_anaphase) {
+      // PRETTY GOOD
+      weight = WEIGHT_ANAPHASE_ANAPHASE;
+    } else if (a_trk_c0->track.front()->label == STATE_anaphase ||
+               a_trk_c1->track.front()->label == STATE_anaphase) {
+      // OK
+      weight = WEIGHT_ANAPHASE;
+    } else {
+      // in this case, none of the criteria are satisfied
+      weight = WEIGHT_OTHER + 10. * P_dead(a_trk_c0) + 10. * P_dead(a_trk_c1);
 
-    return std::exp(-(weight * daughter_angle) / (2. * m_params.lambda_branch));
+      // return here if none of the criteria are satisfied
+      return std::exp(-weight / (2. * m_params.lambda_branch));
+    }
+  }
+
+  // weighted angle between the daughter cells and the parent
+  // use an erf as the weighting function
+  // dot product scales between -1 (ideal) where the daughters are on opposite
+  // sides of the parent, to 1, where the daughters are close in space on the
+  // same side (worst case). Error function will scale these from ~0. to ~1.
+  // meaning that the ideal case minimises the weight
+  daughter_angle = 1.0 - ((1. - std::erf(dot_product * 3.)) / 2.0);
+
+  return std::exp(-(weight * daughter_angle) / (2. * m_params.lambda_branch));
 }

--- a/btrack/src/inference.cc
+++ b/btrack/src/inference.cc
@@ -19,30 +19,28 @@
 ObjectModel::ObjectModel(const Eigen::MatrixXd &transition,
                          const Eigen::MatrixXd &emission,
                          const Eigen::MatrixXd &start)
-    : transition(transition),
-      emission(emission),
-      states(transition.rows()),
+    : transition(transition), emission(emission), states(transition.rows()),
       x_hat(start) {
-    sequence.reserve(RESERVE_STATE_SEQUENCE);
+  sequence.reserve(RESERVE_STATE_SEQUENCE);
 }
 
 ObjectModel::ObjectModel(const Eigen::MatrixXd &transition,
                          const Eigen::MatrixXd &emission)
     : transition(transition), emission(emission), states(transition.rows()) {
-    // set up the start state with a uniform prior
-    x_hat(states);
-    x_hat.fill(1.0 / (double)states);
+  // set up the start state with a uniform prior
+  x_hat(states);
+  x_hat.fill(1.0 / (double)states);
 
-    sequence.reserve(RESERVE_STATE_SEQUENCE);
+  sequence.reserve(RESERVE_STATE_SEQUENCE);
 }
 
 // run the forward pass of the model
 void ObjectModel::forward(const unsigned int observation) {
-    Eigen::VectorXd update(states);
-    for (unsigned int s = 0; s < states; s++) {
-        update = transition.col(s).array() * x_hat.array();
-        x_hat(s) = emission(s, observation) * update.sum();
-    }
+  Eigen::VectorXd update(states);
+  for (unsigned int s = 0; s < states; s++) {
+    update = transition.col(s).array() * x_hat.array();
+    x_hat(s) = emission(s, observation) * update.sum();
+  }
 }
 
 // run the backward pass of the model
@@ -50,14 +48,14 @@ void ObjectModel::backward() {}
 
 // update with a new observation
 void ObjectModel::update(const TrackObjectPtr new_object) {
-    // push back the new observation and update predictions
-    sequence.push_back(new_object->label);
-    forward(new_object->label);
+  // push back the new observation and update predictions
+  sequence.push_back(new_object->label);
+  forward(new_object->label);
 }
 
 Eigen::VectorXd ObjectModel::predict() {
-    // make a prediction based on the transition matrix
-    Eigen::VectorXd prediction(states);
-    prediction = x_hat * transition;
-    return prediction;
+  // make a prediction based on the transition matrix
+  Eigen::VectorXd prediction(states);
+  prediction = x_hat * transition;
+  return prediction;
 }

--- a/btrack/src/interface.cc
+++ b/btrack/src/interface.cc
@@ -32,226 +32,223 @@
 #include "wrapper.h"
 
 EXTERN_DECL {
-    /* =========================================================================
-    CREATE AND DELETE THE INTERFACE
-    ========================================================================= */
+  /* =========================================================================
+  CREATE AND DELETE THE INTERFACE
+  ========================================================================= */
 
-    SHARED_LIB InterfaceWrapper* new_interface() {
-        if (DEBUG) {
-            std::cout << "InterfaceWrapper constructor called in C++"
-                      << std::endl;
-        }
-        return new InterfaceWrapper();
+  SHARED_LIB InterfaceWrapper *new_interface() {
+    if (DEBUG) {
+      std::cout << "InterfaceWrapper constructor called in C++" << std::endl;
     }
+    return new InterfaceWrapper();
+  }
 
-    SHARED_LIB void del_interface(InterfaceWrapper * h) {
-        if (DEBUG) {
-            std::cout << "InterfaceWrapper destructor called in C++ for ";
-            std::cout << h << std::endl;
-        }
-        delete h;
+  SHARED_LIB void del_interface(InterfaceWrapper * h) {
+    if (DEBUG) {
+      std::cout << "InterfaceWrapper destructor called in C++ for ";
+      std::cout << h << std::endl;
     }
+    delete h;
+  }
 
-    /* =========================================================================
-    CHECK SHARED LIB VERSION NUMBER
-    ========================================================================= */
+  /* =========================================================================
+  CHECK SHARED LIB VERSION NUMBER
+  ========================================================================= */
 
-    SHARED_LIB bool check_library_version(
-        InterfaceWrapper * h, const uint8_t a_major, const uint8_t a_minor,
-        const uint8_t a_build) {
-        return h->check_library_version(a_major, a_minor, a_build);
+  SHARED_LIB bool check_library_version(
+      InterfaceWrapper * h, const uint8_t a_major, const uint8_t a_minor,
+      const uint8_t a_build) {
+    return h->check_library_version(a_major, a_minor, a_build);
+  }
+
+  /* =========================================================================
+  SET THE TRACKER TO STORE THE CANDIDATE GRAPH
+  ========================================================================= */
+
+  SHARED_LIB void set_store_candidate_graph(InterfaceWrapper * h,
+                                            const bool a_store_graph) {
+    h->set_store_candidate_graph(a_store_graph);
+  }
+
+  /* =========================================================================
+  UPDATE METHOD SETTINGS
+  ========================================================================= */
+
+  SHARED_LIB void set_update_mode(InterfaceWrapper * h,
+                                  const unsigned int a_update_mode) {
+    // set the tracker update mode
+    h->set_update_mode(a_update_mode);
+  }
+
+  SHARED_LIB void set_update_features(InterfaceWrapper * h,
+                                      const unsigned int a_update_features) {
+    // set the features to use during the tracker update
+    h->set_update_features(a_update_features);
+  }
+
+  /* =========================================================================
+  MOTION MODEL SETTINGS
+  ========================================================================= */
+  SHARED_LIB void motion(InterfaceWrapper * h, const unsigned int measurements,
+                         const unsigned int states, double *A, double *H,
+                         double *P, double *Q, double *R, double dt,
+                         double accuracy, unsigned int max_lost,
+                         double prob_not_assign) {
+    // set the motion_model settings
+    h->set_motion_model(measurements, states, A, H, P, Q, R, dt, accuracy,
+                        max_lost, prob_not_assign);
+  }
+
+  SHARED_LIB void max_search_radius(InterfaceWrapper * h,
+                                    const float maximum_search_radius) {
+    if (DEBUG) {
+      std::cout << "Set maximum search radius to: ";
+      std::cout << maximum_search_radius << std::endl;
     }
+    h->set_max_search_radius(maximum_search_radius);
+  }
 
-    /* =========================================================================
-    SET THE TRACKER TO STORE THE CANDIDATE GRAPH
-    ========================================================================= */
+  /* =========================================================================
+  APPEND NEW OBJECT
+  ========================================================================= */
+  SHARED_LIB void append(InterfaceWrapper * h, const PyTrackObject new_object) {
+    /* append
+    Take a TrackObject and append it to the tracker.
+    */
+    h->append(new_object);
+  }
 
-    SHARED_LIB void set_store_candidate_graph(InterfaceWrapper * h,
-                                              const bool a_store_graph) {
-        h->set_store_candidate_graph(a_store_graph);
-    }
+  /* =========================================================================
+  RUN THE TRACKING CODE
+  ========================================================================= */
+  SHARED_LIB const PyTrackInfo *track(InterfaceWrapper * h) {
+    return h->track();
+  }
 
-    /* =========================================================================
-    UPDATE METHOD SETTINGS
-    ========================================================================= */
+  SHARED_LIB const PyTrackInfo *step(InterfaceWrapper * h,
+                                     const unsigned int n_steps) {
+    // h->step(n_steps);
+    return h->step(n_steps);
+  }
 
-    SHARED_LIB void set_update_mode(InterfaceWrapper * h,
-                                    const unsigned int a_update_mode) {
-        // set the tracker update mode
-        h->set_update_mode(a_update_mode);
-    }
-
-    SHARED_LIB void set_update_features(InterfaceWrapper * h,
-                                        const unsigned int a_update_features) {
-        // set the features to use during the tracker update
-        h->set_update_features(a_update_features);
-    }
-
-    /* =========================================================================
-    MOTION MODEL SETTINGS
-    ========================================================================= */
-    SHARED_LIB void motion(
-        InterfaceWrapper * h, const unsigned int measurements,
-        const unsigned int states, double* A, double* H, double* P, double* Q,
-        double* R, double dt, double accuracy, unsigned int max_lost,
-        double prob_not_assign) {
-        // set the motion_model settings
-        h->set_motion_model(measurements, states, A, H, P, Q, R, dt, accuracy,
-                            max_lost, prob_not_assign);
-    }
-
-    SHARED_LIB void max_search_radius(InterfaceWrapper * h,
-                                      const float maximum_search_radius) {
-        if (DEBUG) {
-            std::cout << "Set maximum search radius to: ";
-            std::cout << maximum_search_radius << std::endl;
-        }
-        h->set_max_search_radius(maximum_search_radius);
-    }
-
-    /* =========================================================================
-    APPEND NEW OBJECT
-    ========================================================================= */
-    SHARED_LIB void append(InterfaceWrapper * h,
-                           const PyTrackObject new_object) {
-        /* append
-        Take a TrackObject and append it to the tracker.
-        */
-        h->append(new_object);
-    }
-
-    /* =========================================================================
-    RUN THE TRACKING CODE
-    ========================================================================= */
-    SHARED_LIB const PyTrackInfo* track(InterfaceWrapper * h) {
-        return h->track();
-    }
-
-    SHARED_LIB const PyTrackInfo* step(InterfaceWrapper * h,
-                                       const unsigned int n_steps) {
-        // h->step(n_steps);
-        return h->step(n_steps);
-    }
-
-    /* =========================================================================
-    GET A TRACKLET
-    ========================================================================= */
-    SHARED_LIB unsigned int track_length(InterfaceWrapper * h,
-                                         const unsigned int trk) {
-        return h->track_length(trk);
-    }
-
-    SHARED_LIB unsigned int get(InterfaceWrapper * h, double* output,
-                                const unsigned int trk) {
-        return h->get_track(output, trk);
-    }
-
-    SHARED_LIB unsigned int get_refs(InterfaceWrapper * h, int* output,
-                                     const unsigned int trk) {
-        return h->get_refs(output, trk);
-    }
-
-    SHARED_LIB unsigned int get_parent(InterfaceWrapper * h,
+  /* =========================================================================
+  GET A TRACKLET
+  ========================================================================= */
+  SHARED_LIB unsigned int track_length(InterfaceWrapper * h,
                                        const unsigned int trk) {
-        return h->get_parent(trk);
-    }
+    return h->track_length(trk);
+  }
 
-    SHARED_LIB unsigned int get_root(InterfaceWrapper * h,
-                                     const unsigned int trk) {
-        return h->get_root(trk);
-    }
+  SHARED_LIB unsigned int get(InterfaceWrapper * h, double *output,
+                              const unsigned int trk) {
+    return h->get_track(output, trk);
+  }
 
-    SHARED_LIB unsigned int get_children(InterfaceWrapper * h, int* children,
-                                         const unsigned int trk) {
-        return h->get_children(children, trk);
-    }
-
-    SHARED_LIB unsigned int get_ID(InterfaceWrapper * h,
+  SHARED_LIB unsigned int get_refs(InterfaceWrapper * h, int *output,
                                    const unsigned int trk) {
-        return h->get_ID(trk);
-    }
+    return h->get_refs(output, trk);
+  }
 
-    SHARED_LIB unsigned int get_fate(InterfaceWrapper * h,
+  SHARED_LIB unsigned int get_parent(InterfaceWrapper * h,
                                      const unsigned int trk) {
-        return h->get_fate(trk);
-    }
+    return h->get_parent(trk);
+  }
 
-    SHARED_LIB unsigned int get_generation(InterfaceWrapper * h,
+  SHARED_LIB unsigned int get_root(InterfaceWrapper * h,
+                                   const unsigned int trk) {
+    return h->get_root(trk);
+  }
+
+  SHARED_LIB unsigned int get_children(InterfaceWrapper * h, int *children,
+                                       const unsigned int trk) {
+    return h->get_children(children, trk);
+  }
+
+  SHARED_LIB unsigned int get_ID(InterfaceWrapper * h, const unsigned int trk) {
+    return h->get_ID(trk);
+  }
+
+  SHARED_LIB unsigned int get_fate(InterfaceWrapper * h,
+                                   const unsigned int trk) {
+    return h->get_fate(trk);
+  }
+
+  SHARED_LIB unsigned int get_generation(InterfaceWrapper * h,
+                                         const unsigned int trk) {
+    return h->get_generation(trk);
+  }
+
+  SHARED_LIB unsigned int get_kalman_mu(InterfaceWrapper * h, double *output,
+                                        const unsigned int trk) {
+    return h->get_kalman_mu(output, trk);
+  }
+
+  SHARED_LIB unsigned int get_kalman_covar(InterfaceWrapper * h, double *output,
                                            const unsigned int trk) {
-        return h->get_generation(trk);
-    }
+    return h->get_kalman_covar(output, trk);
+  }
 
-    SHARED_LIB unsigned int get_kalman_mu(InterfaceWrapper * h, double* output,
+  SHARED_LIB unsigned int get_kalman_pred(InterfaceWrapper * h, double *output,
                                           const unsigned int trk) {
-        return h->get_kalman_mu(output, trk);
-    }
+    return h->get_kalman_pred(output, trk);
+  }
 
-    SHARED_LIB unsigned int get_kalman_covar(
-        InterfaceWrapper * h, double* output, const unsigned int trk) {
-        return h->get_kalman_covar(output, trk);
-    }
+  SHARED_LIB unsigned int get_label(InterfaceWrapper * h, unsigned int *output,
+                                    const unsigned int trk) {
+    return h->get_label(output, trk);
+  }
 
-    SHARED_LIB unsigned int get_kalman_pred(
-        InterfaceWrapper * h, double* output, const unsigned int trk) {
-        return h->get_kalman_pred(output, trk);
-    }
+  SHARED_LIB PyTrackObject get_dummy(InterfaceWrapper * h, const int obj) {
+    return h->get_dummy(obj);
+  }
 
-    SHARED_LIB unsigned int get_label(
-        InterfaceWrapper * h, unsigned int* output, const unsigned int trk) {
-        return h->get_label(output, trk);
-    }
+  /* =========================================================================
+  RETURN THE NUMBER OF FOUND TRACKS
+  ========================================================================= */
+  SHARED_LIB unsigned int size(InterfaceWrapper * h) { return h->size(); }
 
-    SHARED_LIB PyTrackObject get_dummy(InterfaceWrapper * h, const int obj) {
-        return h->get_dummy(obj);
-    }
+  /* =========================================================================
+  RETURN OR SET THE IMAGING VOLUME
+  ========================================================================= */
 
-    /* =========================================================================
-    RETURN THE NUMBER OF FOUND TRACKS
-    ========================================================================= */
-    SHARED_LIB unsigned int size(InterfaceWrapper * h) { return h->size(); }
+  SHARED_LIB void get_volume(InterfaceWrapper * h, double *volume) {
+    h->get_volume(volume);
+  }
 
-    /* =========================================================================
-    RETURN OR SET THE IMAGING VOLUME
-    ========================================================================= */
+  SHARED_LIB void set_volume(InterfaceWrapper * h, double *volume) {
+    h->set_volume(volume);
+  }
 
-    SHARED_LIB void get_volume(InterfaceWrapper * h, double* volume) {
-        h->get_volume(volume);
-    }
+  /* =========================================================================
+  GRAPH EDGES
+  ========================================================================= */
 
-    SHARED_LIB void set_volume(InterfaceWrapper * h, double* volume) {
-        h->set_volume(volume);
-    }
+  SHARED_LIB unsigned int num_edges(InterfaceWrapper * h) {
+    return h->num_edges();
+  }
 
-    /* =========================================================================
-    GRAPH EDGES
-    ========================================================================= */
+  SHARED_LIB PyGraphEdge get_graph_edge(InterfaceWrapper * h,
+                                        const unsigned int edge_idx) {
+    return h->get_graph_edge(edge_idx);
+  }
 
-    SHARED_LIB unsigned int num_edges(InterfaceWrapper * h) {
-        return h->num_edges();
-    }
+  /* =========================================================================
+  OPTIMIZER
+  ========================================================================= */
 
-    SHARED_LIB PyGraphEdge get_graph_edge(InterfaceWrapper * h,
-                                          const unsigned int edge_idx) {
-        return h->get_graph_edge(edge_idx);
-    }
+  SHARED_LIB unsigned int create_hypotheses(
+      InterfaceWrapper * h, const PyHypothesisParams params,
+      const unsigned int a_start_frame, const unsigned int a_end_frame) {
+    return h->create_hypotheses(params, a_start_frame, a_end_frame);
+  }
 
-    /* =========================================================================
-    OPTIMIZER
-    ========================================================================= */
+  SHARED_LIB PyHypothesis get_hypothesis(InterfaceWrapper * h,
+                                         const unsigned int a_ID) {
+    return h->get_hypothesis(a_ID);
+  };
 
-    SHARED_LIB unsigned int create_hypotheses(
-        InterfaceWrapper * h, const PyHypothesisParams params,
-        const unsigned int a_start_frame, const unsigned int a_end_frame) {
-        return h->create_hypotheses(params, a_start_frame, a_end_frame);
-    }
-
-    SHARED_LIB PyHypothesis get_hypothesis(InterfaceWrapper * h,
-                                           const unsigned int a_ID) {
-        return h->get_hypothesis(a_ID);
-    };
-
-    SHARED_LIB void merge(InterfaceWrapper * h, unsigned int* a_hypotheses,
-                          unsigned int n_hypotheses) {
-        h->merge(a_hypotheses, n_hypotheses);
-    }
+  SHARED_LIB void merge(InterfaceWrapper * h, unsigned int *a_hypotheses,
+                        unsigned int n_hypotheses) {
+    h->merge(a_hypotheses, n_hypotheses);
+  }
 }

--- a/btrack/src/manager.cc
+++ b/btrack/src/manager.cc
@@ -20,87 +20,88 @@
 
 bool compare_hypothesis_time(const Hypothesis &hypothesis_i,
                              const Hypothesis &hypothesis_j) {
-    return hypothesis_i.trk_ID->track[0]->t < hypothesis_j.trk_ID->track[0]->t;
+  return hypothesis_i.trk_ID->track[0]->t < hypothesis_j.trk_ID->track[0]->t;
 }
 
 bool compare_track_start_time(const TrackletPtr &trk_i,
                               const TrackletPtr &trk_j) {
-    return trk_i->track[0]->t < trk_j->track[0]->t;
+  return trk_i->track[0]->t < trk_j->track[0]->t;
 }
 
 // take two tracks and merge the contents, rename the merged track and mark for
 // removal at the end
 void join_tracks(const TrackletPtr &parent_trk, const TrackletPtr &join_trk) {
-    if (DEBUG) std::cout << join_trk->ID << ",";
+  if (DEBUG)
+    std::cout << join_trk->ID << ",";
 
-    // append the pointers to the objects to the parent track object
-    for (size_t i = 0; i < join_trk->length(); i++) {
-        parent_trk->append(join_trk->track[i], true);
+  // append the pointers to the objects to the parent track object
+  for (size_t i = 0; i < join_trk->length(); i++) {
+    parent_trk->append(join_trk->track[i], true);
+  }
+
+  // set the renamed ID and a flag to remove
+  join_trk->renamed_ID = parent_trk->ID;
+  join_trk->to_remove(true);
+
+  // set the fate of the parent track to that of the joined track
+  parent_trk->fate = join_trk->fate;
+
+  // set the children
+  if (join_trk->child_one != 0 && join_trk->child_two != 0) {
+    if (DEBUG) {
+      std::cout << parent_trk->ID << " -> [";
+      std::cout << join_trk->child_one << ",";
+      std::cout << join_trk->child_two << "]" << std::endl;
     }
 
-    // set the renamed ID and a flag to remove
-    join_trk->renamed_ID = parent_trk->ID;
-    join_trk->to_remove(true);
-
-    // set the fate of the parent track to that of the joined track
-    parent_trk->fate = join_trk->fate;
-
-    // set the children
-    if (join_trk->child_one != 0 && join_trk->child_two != 0) {
-        if (DEBUG) {
-            std::cout << parent_trk->ID << " -> [";
-            std::cout << join_trk->child_one << ",";
-            std::cout << join_trk->child_two << "]" << std::endl;
-        }
-
-        // TODO(arl): raise a warning if these have already been set?
-        parent_trk->child_one = join_trk->child_one;
-        parent_trk->child_two = join_trk->child_two;
-    }
+    // TODO(arl): raise a warning if these have already been set?
+    parent_trk->child_one = join_trk->child_one;
+    parent_trk->child_two = join_trk->child_two;
+  }
 }
 
 // branches
 void branch_tracks(const BranchHypothesis &branch) {
-    // makes some local pointers to the tracklets
-    TrackletPtr parent_trk = std::get<0>(branch);
-    TrackletPtr child_one_trk = std::get<1>(branch);
-    TrackletPtr child_two_trk = std::get<2>(branch);
+  // makes some local pointers to the tracklets
+  TrackletPtr parent_trk = std::get<0>(branch);
+  TrackletPtr child_one_trk = std::get<1>(branch);
+  TrackletPtr child_two_trk = std::get<2>(branch);
 
-    // local ID for parent track (could be renamed, so need to check)
-    unsigned int ID;
+  // local ID for parent track (could be renamed, so need to check)
+  unsigned int ID;
 
-    // first check to see whether the parent has been renamed
-    if (parent_trk->to_remove()) {
-        ID = parent_trk->renamed_ID;
-    } else {
-        ID = parent_trk->ID;
-    }
+  // first check to see whether the parent has been renamed
+  if (parent_trk->to_remove()) {
+    ID = parent_trk->renamed_ID;
+  } else {
+    ID = parent_trk->ID;
+  }
 
-    // output some details?
-    if (DEBUG) {
-        std::cout << parent_trk->ID << " (renamed: " << ID << ") {";
-        std::cout << child_one_trk->ID << ", ";
-        std::cout << child_two_trk->ID << "}";
-    }
+  // output some details?
+  if (DEBUG) {
+    std::cout << parent_trk->ID << " (renamed: " << ID << ") {";
+    std::cout << child_one_trk->ID << ", ";
+    std::cout << child_two_trk->ID << "}";
+  }
 
-    // set the parent ID for these children
-    child_one_trk->parent = ID;
-    child_two_trk->parent = ID;
+  // set the parent ID for these children
+  child_one_trk->parent = ID;
+  child_two_trk->parent = ID;
 
-    // set the parent track children also
-    parent_trk->child_one = child_one_trk->ID;
-    parent_trk->child_two = child_two_trk->ID;
+  // set the parent track children also
+  parent_trk->child_one = child_one_trk->ID;
+  parent_trk->child_two = child_two_trk->ID;
 
-    // set the fate of the parent as 'divided'
-    parent_trk->fate = TYPE_Pdivn;
+  // set the fate of the parent as 'divided'
+  parent_trk->fate = TYPE_Pdivn;
 }
 
 void TrackManager::set_store_candidate_graph(const bool a_store_graph) {
-    m_store_candidate_graph = a_store_graph;
-    m_graph_edges.clear();
-    if (a_store_graph) {
-        m_graph_edges.reserve(RESERVE_GRAPH_EDGES);
-    }
+  m_store_candidate_graph = a_store_graph;
+  m_graph_edges.clear();
+  if (a_store_graph) {
+    m_graph_edges.reserve(RESERVE_GRAPH_EDGES);
+  }
 }
 
 // add a graph edge
@@ -108,27 +109,27 @@ void TrackManager::push_edge(const TrackObjectPtr &a_node_src,
                              const TrackObjectPtr &a_node_dst,
                              const float a_score,
                              const unsigned int a_edge_type) {
-    // if we're not storing them, then pass
-    if (!m_store_candidate_graph) {
-        return;
-    }
+  // if we're not storing them, then pass
+  if (!m_store_candidate_graph) {
+    return;
+  }
 
-    // create and store the edge objects
-    PyGraphEdge edge;
-    edge.source = a_node_src->ID;
-    edge.target = a_node_dst->ID;
-    edge.score = a_score;
-    edge.type = a_edge_type;
-    m_graph_edges.push_back(edge);
+  // create and store the edge objects
+  PyGraphEdge edge;
+  edge.source = a_node_src->ID;
+  edge.target = a_node_dst->ID;
+  edge.score = a_score;
+  edge.type = a_edge_type;
+  m_graph_edges.push_back(edge);
 }
 
 PyGraphEdge TrackManager::get_edge(const size_t idx) const {
-    // TODO: we may want to index beyond the end of the edges stored in the
-    // `m_graph_edges` vector, to include those edges built by the hypothesis
-    // engine. To do so, we need to index into the hypotheses for branches,
-    // links and merges.
+  // TODO: we may want to index beyond the end of the edges stored in the
+  // `m_graph_edges` vector, to include those edges built by the hypothesis
+  // engine. To do so, we need to index into the hypotheses for branches,
+  // links and merges.
 
-    return m_graph_edges[idx];
+  return m_graph_edges[idx];
 }
 
 size_t TrackManager::num_edges(void) const { return m_graph_edges.size(); }
@@ -136,356 +137,358 @@ size_t TrackManager::num_edges(void) const { return m_graph_edges.size(); }
 // split a track to remove forbidden transitions
 void TrackManager::split(const TrackletPtr &a_trk, const unsigned int a_label_i,
                          const unsigned int a_label_j) {
-    // if this is already flagged to be removed, return
-    if (a_trk->to_remove()) return;
+  // if this is already flagged to be removed, return
+  if (a_trk->to_remove())
+    return;
 
-    // return if the track is too short
-    if (a_trk->track.size() < 2) return;
+  // return if the track is too short
+  if (a_trk->track.size() < 2)
+    return;
 
-    // iterate over the track and make a list of indices where splits
-    // should occur
-    std::vector<unsigned int> split_indices;
+  // iterate over the track and make a list of indices where splits
+  // should occur
+  std::vector<unsigned int> split_indices;
 
-    for (size_t i = 0; i < a_trk->track.size() - 1; i++) {
-        if (a_trk->track[i]->label == a_label_i &&
-            a_trk->track[i + 1]->label == a_label_j) {
-            // if we satisfy the condition, push the index
-            split_indices.push_back(i + 1);
-        }
+  for (size_t i = 0; i < a_trk->track.size() - 1; i++) {
+    if (a_trk->track[i]->label == a_label_i &&
+        a_trk->track[i + 1]->label == a_label_j) {
+      // if we satisfy the condition, push the index
+      split_indices.push_back(i + 1);
     }
+  }
 
-    // return if there is nothing to do
-    if (split_indices.empty()) return;
+  // return if there is nothing to do
+  if (split_indices.empty())
+    return;
 
-    // TODO(arl): actually split the tracks!
-    // std::cout << "Residual splits need to be performed -> " << a_trk->ID <<
-    // std::endl;
+  // TODO(arl): actually split the tracks!
+  // std::cout << "Residual splits need to be performed -> " << a_trk->ID <<
+  // std::endl;
 }
 
 TrackletPtr TrackManager::get_track_by_ID(const size_t a_ID) const {
-    for (size_t i = 0; i < m_tracks.size(); i++) {
-        if (m_tracks[i]->ID == a_ID) {
-            // std::cout << "ID: " << a_ID << " --> index: " << i << std::endl;
-            return m_tracks[i];
-        }
+  for (size_t i = 0; i < m_tracks.size(); i++) {
+    if (m_tracks[i]->ID == a_ID) {
+      // std::cout << "ID: " << a_ID << " --> index: " << i << std::endl;
+      return m_tracks[i];
     }
+  }
 
-    // what happens if this ID is not found?!
-    std::cout << "Track ID: " << a_ID << " not found." << std::endl;
-    throw std::runtime_error("Track not found.");
+  // what happens if this ID is not found?!
+  std::cout << "Track ID: " << a_ID << " not found." << std::endl;
+  throw std::runtime_error("Track not found.");
 }
 
 // take a list of hypotheses and re-organise the tracks following optimisation
 void TrackManager::merge(const std::vector<Hypothesis> &a_hypotheses) {
-    if (a_hypotheses.empty()) {
-        if (DEBUG) std::cout << "Hypothesis list is empty!" << std::endl;
-        return;
+  if (a_hypotheses.empty()) {
+    if (DEBUG)
+      std::cout << "Hypothesis list is empty!" << std::endl;
+    return;
+  }
+
+  if (m_tracks.empty()) {
+    if (DEBUG)
+      std::cout << "Track manager is empty!" << std::endl;
+    return;
+  }
+
+  // get the number of hypotheses
+  size_t n_hypotheses = a_hypotheses.size();
+
+  // make some space for the different hypotheses
+  m_links = HypothesisMap<JoinHypothesis>(m_tracks.size());
+  m_branches = HypothesisMap<BranchHypothesis>(m_tracks.size());
+
+  // loop through the hypotheses, split into link and branch types
+  for (size_t i = 0; i < n_hypotheses; i++) {
+    Hypothesis h = a_hypotheses[i];
+
+    // set the fate of each track as the 'accepted' hypothesis. these will
+    // be overwritten in the link and division events
+    h.trk_ID->fate = h.hypothesis;
+
+    switch (h.hypothesis) {
+    // linkage
+    case TYPE_Plink:
+      if (DEBUG) {
+        std::cout << "P_link: " << h.trk_ID->ID << "->" << h.trk_link_ID->ID;
+        std::cout << " [Score: " << h.probability << "]" << std::endl;
+      }
+
+      // push a link hypothesis
+      m_links.push(h.trk_ID->ID, JoinHypothesis(h.trk_ID, h.trk_link_ID));
+      break;
+
+    // branch
+    case TYPE_Pdivn:
+      if (DEBUG) {
+        std::cout << "P_branch: " << h.trk_ID->ID << "->"
+                  << h.trk_child_one_ID->ID;
+        std::cout << " [Score: " << h.probability << "]" << std::endl;
+        std::cout << "P_branch: " << h.trk_ID->ID << "->"
+                  << h.trk_child_two_ID->ID;
+        std::cout << " [Score: " << h.probability << "]" << std::endl;
+      }
+
+      // push a branch hypothesis
+      m_branches.push(
+          h.trk_ID->ID,
+          BranchHypothesis(h.trk_ID, h.trk_child_one_ID, h.trk_child_two_ID));
+      break;
+
+    case TYPE_Pmrge:
+      // do nothing if we have a merge
+      break;
     }
+  }
 
-    if (m_tracks.empty()) {
-        if (DEBUG) std::cout << "Track manager is empty!" << std::endl;
-        return;
+  /* Merge the tracklets.
+
+    i. Traverse the list of linkages.
+    ii. Take the first tracklet, append subsequent objects to that tracklet,
+        do not update object model
+    iii. Rename subsequent tracklets
+    iv. set the parent flags for the tracks
+    v. Remove merged tracks
+
+  */
+
+  // NOTE(arl): do the branches first?
+  // OK, now that we've merged all of the tracks, we want to set various flags
+  // to show that divisions have occurred
+
+  for (size_t parent_i = 0; parent_i < m_branches.size(); parent_i++) {
+    if (!m_branches[parent_i].empty()) {
+      if (DEBUG)
+        std::cout << "Branch: [";
+      branch_tracks(m_branches[parent_i][0]);
+      if (DEBUG)
+        std::cout << "]" << std::endl;
     }
+  }
 
-    // get the number of hypotheses
-    size_t n_hypotheses = a_hypotheses.size();
+  std::set<unsigned int> used;
+  unsigned int child_j;
 
-    // make some space for the different hypotheses
-    m_links = HypothesisMap<JoinHypothesis>(m_tracks.size());
-    m_branches = HypothesisMap<BranchHypothesis>(m_tracks.size());
+  // let's try to follow the links, iterate over the link hypotheses
+  for (size_t parent_i = 0; parent_i < m_links.size(); parent_i++) {
+    // if we have a linkage, and we haven't already used this...
+    if (!m_links[parent_i].empty() && used.count(parent_i) == 0) {
+      // now follow the chain
+      used.emplace(parent_i);
+      child_j = m_links[parent_i][0].second->ID;
 
-    // loop through the hypotheses, split into link and branch types
-    for (size_t i = 0; i < n_hypotheses; i++) {
-        Hypothesis h = a_hypotheses[i];
+      // merge the tracks
+      if (DEBUG)
+        std::cout << "Merge: [" << parent_i << ",";
+      join_tracks(m_links[parent_i][0].first, m_links[parent_i][0].second);
 
-        // set the fate of each track as the 'accepted' hypothesis. these will
-        // be overwritten in the link and division events
-        h.trk_ID->fate = h.hypothesis;
+      // mark the child as used
+      used.emplace(child_j);
 
-        switch (h.hypothesis) {
-            // linkage
-            case TYPE_Plink:
-                if (DEBUG) {
-                    std::cout << "P_link: " << h.trk_ID->ID << "->"
-                              << h.trk_link_ID->ID;
-                    std::cout << " [Score: " << h.probability << "]"
-                              << std::endl;
-                }
+      // traverse the chain
+      while (!m_links[child_j].empty()) {
+        // merge the next track
+        join_tracks(m_links[parent_i][0].first, m_links[child_j][0].second);
 
-                // push a link hypothesis
-                m_links.push(h.trk_ID->ID,
-                             JoinHypothesis(h.trk_ID, h.trk_link_ID));
-                break;
-
-            // branch
-            case TYPE_Pdivn:
-                if (DEBUG) {
-                    std::cout << "P_branch: " << h.trk_ID->ID << "->"
-                              << h.trk_child_one_ID->ID;
-                    std::cout << " [Score: " << h.probability << "]"
-                              << std::endl;
-                    std::cout << "P_branch: " << h.trk_ID->ID << "->"
-                              << h.trk_child_two_ID->ID;
-                    std::cout << " [Score: " << h.probability << "]"
-                              << std::endl;
-                }
-
-                // push a branch hypothesis
-                m_branches.push(h.trk_ID->ID,
-                                BranchHypothesis(h.trk_ID, h.trk_child_one_ID,
-                                                 h.trk_child_two_ID));
-                break;
-
-            case TYPE_Pmrge:
-                // do nothing if we have a merge
-                break;
-        }
+        // iterate
+        child_j = m_links[child_j][0].second->ID;
+        used.emplace(child_j);
+      }
+      if (DEBUG)
+        std::cout << "]" << std::endl;
     }
+  }
 
-    /* Merge the tracklets.
+  // // Sanity check, have we used all the possible joins?
+  // for (size_t parent_i=0; parent_i<m_links.size(); parent_i++) {
+  //   if (used.count(parent_i) == 0) {
+  //     std::cout << "Parent track: " << m_links[parent_i][0].first << "not
+  //     used!" << std::endl;
+  //   }
+  // }
 
-      i. Traverse the list of linkages.
-      ii. Take the first tracklet, append subsequent objects to that tracklet,
-          do not update object model
-      iii. Rename subsequent tracklets
-      iv. set the parent flags for the tracks
-      v. Remove merged tracks
-
-    */
-
-    // NOTE(arl): do the branches first?
-    // OK, now that we've merged all of the tracks, we want to set various flags
-    // to show that divisions have occurred
-
-    for (size_t parent_i = 0; parent_i < m_branches.size(); parent_i++) {
-        if (!m_branches[parent_i].empty()) {
-            if (DEBUG) std::cout << "Branch: [";
-            branch_tracks(m_branches[parent_i][0]);
-            if (DEBUG) std::cout << "]" << std::endl;
-        }
-    }
-
-    std::set<unsigned int> used;
-    unsigned int child_j;
-
-    // let's try to follow the links, iterate over the link hypotheses
-    for (size_t parent_i = 0; parent_i < m_links.size(); parent_i++) {
-        // if we have a linkage, and we haven't already used this...
-        if (!m_links[parent_i].empty() && used.count(parent_i) == 0) {
-            // now follow the chain
-            used.emplace(parent_i);
-            child_j = m_links[parent_i][0].second->ID;
-
-            // merge the tracks
-            if (DEBUG) std::cout << "Merge: [" << parent_i << ",";
-            join_tracks(m_links[parent_i][0].first,
-                        m_links[parent_i][0].second);
-
-            // mark the child as used
-            used.emplace(child_j);
-
-            // traverse the chain
-            while (!m_links[child_j].empty()) {
-                // merge the next track
-                join_tracks(m_links[parent_i][0].first,
-                            m_links[child_j][0].second);
-
-                // iterate
-                child_j = m_links[child_j][0].second->ID;
-                used.emplace(child_j);
-            }
-            if (DEBUG) std::cout << "]" << std::endl;
-        }
-    }
-
-    // // Sanity check, have we used all the possible joins?
-    // for (size_t parent_i=0; parent_i<m_links.size(); parent_i++) {
-    //   if (used.count(parent_i) == 0) {
-    //     std::cout << "Parent track: " << m_links[parent_i][0].first << "not
-    //     used!" << std::endl;
-    //   }
-    // }
-
-    // TODO(arl): do a final splitting round to make sure that we haven't
-    // joined any tracks that have a METAPHASE->ANAPHASE transition
-    if (SPLIT_INCORRECTLY_JOINED_TRACKS) {
-        for (size_t i = 0; i < m_tracks.size(); i++) {
-            split(m_tracks[i], STATE_metaphase, STATE_anaphase);
-        }
-    }
-
-    // erase those tracks marked for removal (i.e. those that have been merged)
-    if (DEBUG) std::cout << "Tracks before merge: " << m_tracks.size();
-
-    // remove the tracks if labelled to_remove
-    m_tracks.erase(
-        std::remove_if(m_tracks.begin(), m_tracks.end(),
-                       [](const TrackletPtr &t) { return t->to_remove(); }),
-        m_tracks.end());
-
-    // give the user some more output
-    if (DEBUG) std::cout << ", now " << m_tracks.size() << std::endl;
-
-    // check that forward and reverse traversal of the trees is correct
+  // TODO(arl): do a final splitting round to make sure that we haven't
+  // joined any tracks that have a METAPHASE->ANAPHASE transition
+  if (SPLIT_INCORRECTLY_JOINED_TRACKS) {
     for (size_t i = 0; i < m_tracks.size(); i++) {
-        if (m_tracks[i]->has_children()) {
-            unsigned int parent_ID = m_tracks[i]->ID;
-
-            // get pointers to the children and do a reverse look-up to check
-            // the parent ID matches, if not, rename it
-            TrackletPtr child_i = get_track_by_ID(m_tracks[i]->child_one);
-            TrackletPtr child_j = get_track_by_ID(m_tracks[i]->child_two);
-
-            if (child_i->parent != parent_ID) {
-                // std::cout << "Mislabeled parent ID " << child_i->ID;
-                // std::cout << "->" << parent_ID << std::endl;
-                child_i->parent = parent_ID;
-            }
-
-            if (child_j->parent != parent_ID) {
-                // std::cout << "Mislabeled parent ID " << child_j->ID;
-                // std::cout << "->" << parent_ID << std::endl;
-                child_j->parent = parent_ID;
-            }
-        }
+      split(m_tracks[i], STATE_metaphase, STATE_anaphase);
     }
+  }
 
-    // build the lineage trees
-    build_trees();
+  // erase those tracks marked for removal (i.e. those that have been merged)
+  if (DEBUG)
+    std::cout << "Tracks before merge: " << m_tracks.size();
 
-    // now finalise everything
-    finalise();
+  // remove the tracks if labelled to_remove
+  m_tracks.erase(
+      std::remove_if(m_tracks.begin(), m_tracks.end(),
+                     [](const TrackletPtr &t) { return t->to_remove(); }),
+      m_tracks.end());
+
+  // give the user some more output
+  if (DEBUG)
+    std::cout << ", now " << m_tracks.size() << std::endl;
+
+  // check that forward and reverse traversal of the trees is correct
+  for (size_t i = 0; i < m_tracks.size(); i++) {
+    if (m_tracks[i]->has_children()) {
+      unsigned int parent_ID = m_tracks[i]->ID;
+
+      // get pointers to the children and do a reverse look-up to check
+      // the parent ID matches, if not, rename it
+      TrackletPtr child_i = get_track_by_ID(m_tracks[i]->child_one);
+      TrackletPtr child_j = get_track_by_ID(m_tracks[i]->child_two);
+
+      if (child_i->parent != parent_ID) {
+        // std::cout << "Mislabeled parent ID " << child_i->ID;
+        // std::cout << "->" << parent_ID << std::endl;
+        child_i->parent = parent_ID;
+      }
+
+      if (child_j->parent != parent_ID) {
+        // std::cout << "Mislabeled parent ID " << child_j->ID;
+        // std::cout << "->" << parent_ID << std::endl;
+        child_j->parent = parent_ID;
+      }
+    }
+  }
+
+  // build the lineage trees
+  build_trees();
+
+  // now finalise everything
+  finalise();
 }
 
 // build lineage trees
 void TrackManager::build_trees(void) {
-    // do nothing yet.
-    // return;
+  // do nothing yet.
+  // return;
 
-    // make a set of used tracks
-    std::set<unsigned int> used;
+  // make a set of used tracks
+  std::set<unsigned int> used;
 
-    // sort the tracks in time order
-    std::sort(m_tracks.begin(), m_tracks.end(), compare_track_start_time);
+  // sort the tracks in time order
+  std::sort(m_tracks.begin(), m_tracks.end(), compare_track_start_time);
 
-    for (size_t i = 0; i < m_tracks.size(); i++) {
-        // has this track already been used?
-        if (used.count(m_tracks[i]->ID) < 1) {
-            // create a new node and associate the track with it
-            LineageTreeNode root_node = LineageTreeNode(m_tracks[i]);
+  for (size_t i = 0; i < m_tracks.size(); i++) {
+    // has this track already been used?
+    if (used.count(m_tracks[i]->ID) < 1) {
+      // create a new node and associate the track with it
+      LineageTreeNode root_node = LineageTreeNode(m_tracks[i]);
 
-            // since we know this is a root node, set the generational depth to
-            // zero
-            root_node.m_depth = 0;
+      // since we know this is a root node, set the generational depth to
+      // zero
+      root_node.m_depth = 0;
 
-            // check to see whether the track has children, if so, traverse the
-            // tree
-            if (root_node.has_children()) {
-                // start a queue
-                std::vector<LineageTreeNode> queue;
-                queue.push_back(root_node);
+      // check to see whether the track has children, if so, traverse the
+      // tree
+      if (root_node.has_children()) {
+        // start a queue
+        std::vector<LineageTreeNode> queue;
+        queue.push_back(root_node);
 
-                while (!queue.empty()) {
-                    // get the first item and erase it (i.e. pop front)
-                    LineageTreeNode node = queue[0];
-                    queue.erase(queue.begin());
+        while (!queue.empty()) {
+          // get the first item and erase it (i.e. pop front)
+          LineageTreeNode node = queue[0];
+          queue.erase(queue.begin());
 
-                    if (node.has_children()) {
-                        // get the tracks by ID
-                        TrackletPtr track_left =
-                            get_track_by_ID(node.m_track->child_one);
-                        TrackletPtr track_right =
-                            get_track_by_ID(node.m_track->child_two);
+          if (node.has_children()) {
+            // get the tracks by ID
+            TrackletPtr track_left = get_track_by_ID(node.m_track->child_one);
+            TrackletPtr track_right = get_track_by_ID(node.m_track->child_two);
 
-                        LineageTreeNode left_node = LineageTreeNode(track_left);
-                        LineageTreeNode right_node =
-                            LineageTreeNode(track_right);
+            LineageTreeNode left_node = LineageTreeNode(track_left);
+            LineageTreeNode right_node = LineageTreeNode(track_right);
 
-                        // set the generational depth as one greater than the
-                        // parent node
-                        unsigned int generation_of_children = node.m_depth + 1;
-                        left_node.m_depth = generation_of_children;
-                        right_node.m_depth = generation_of_children;
+            // set the generational depth as one greater than the
+            // parent node
+            unsigned int generation_of_children = node.m_depth + 1;
+            left_node.m_depth = generation_of_children;
+            right_node.m_depth = generation_of_children;
 
-                        // update the tracks with the correct root note ID
-                        track_left->root = root_node.m_track->ID;
-                        track_right->root = root_node.m_track->ID;
+            // update the tracks with the correct root note ID
+            track_left->root = root_node.m_track->ID;
+            track_right->root = root_node.m_track->ID;
 
-                        // set the tracklets generational depth
-                        track_left->generation = generation_of_children;
-                        track_right->generation = generation_of_children;
+            // set the tracklets generational depth
+            track_left->generation = generation_of_children;
+            track_right->generation = generation_of_children;
 
-                        // push these nodes onto the queue for discovery
-                        queue.push_back(left_node);
-                        queue.push_back(right_node);
+            // push these nodes onto the queue for discovery
+            queue.push_back(left_node);
+            queue.push_back(right_node);
 
-                        // flag these as used
-                        used.insert(track_left->ID);
-                        used.insert(track_right->ID);
+            // flag these as used
+            used.insert(track_left->ID);
+            used.insert(track_right->ID);
 
-                    }  // has_children
+          } // has_children
 
-                }  // queue empty
-            }      // root has_children
+        } // queue empty
+      }   // root has_children
 
-            // push this onto the vector of trees
-            m_trees.push_back(root_node);
+      // push this onto the vector of trees
+      m_trees.push_back(root_node);
 
-            // NOTE(arl): this is probably unnecessary, but we will do it anyway
-            // add this to the used list
-            used.insert(m_tracks[i]->ID);
+      // NOTE(arl): this is probably unnecessary, but we will do it anyway
+      // add this to the used list
+      used.insert(m_tracks[i]->ID);
 
-        }  // is track already used?
+    } // is track already used?
 
-    }  // i
+  } // i
 }
 
 // finalise the tracks by trimming them to length and making a list of the
 // dummy objects used
 void TrackManager::finalise(void) {
-    if (DEBUG) std::cout << "Finalising all tracks..." << std::endl;
+  if (DEBUG)
+    std::cout << "Finalising all tracks..." << std::endl;
 
-    // set the global dummy ID counter here
-    int dummy_ID = -1;
-    m_dummies.clear();
+  // set the global dummy ID counter here
+  int dummy_ID = -1;
+  m_dummies.clear();
 
-    // iterate over the tracks, trim and renumber
-    for (size_t i = 0; i < m_tracks.size(); i++) {
-        // first trim any tracks to remove any trailing dummy objects
-        m_tracks[i]->trim();
+  // iterate over the tracks, trim and renumber
+  for (size_t i = 0; i < m_tracks.size(); i++) {
+    // first trim any tracks to remove any trailing dummy objects
+    m_tracks[i]->trim();
 
-        // now give the dummies unique IDs
-        for (size_t o = 0; o < m_tracks[i]->track.size(); o++) {
-            if (m_tracks[i]->track[o]->dummy) {
-                m_tracks[i]->track[o]->ID = dummy_ID;
-                dummy_ID--;
-                // add this dummy to the list
-                m_dummies.push_back(m_tracks[i]->track[o]);
-            }
-        }
-
-        // finally, if the root node remains unset, change it to the track ID
-        if (m_tracks[i]->root == 0) {
-            m_tracks[i]->root = m_tracks[i]->ID;
-        }
-
-        // if the parent node remains unset, change it to the track ID
-        if (m_tracks[i]->parent == 0) {
-            m_tracks[i]->parent = m_tracks[i]->ID;
-        }
+    // now give the dummies unique IDs
+    for (size_t o = 0; o < m_tracks[i]->track.size(); o++) {
+      if (m_tracks[i]->track[o]->dummy) {
+        m_tracks[i]->track[o]->ID = dummy_ID;
+        dummy_ID--;
+        // add this dummy to the list
+        m_dummies.push_back(m_tracks[i]->track[o]);
+      }
     }
+
+    // finally, if the root node remains unset, change it to the track ID
+    if (m_tracks[i]->root == 0) {
+      m_tracks[i]->root = m_tracks[i]->ID;
+    }
+
+    // if the parent node remains unset, change it to the track ID
+    if (m_tracks[i]->parent == 0) {
+      m_tracks[i]->parent = m_tracks[i]->ID;
+    }
+  }
 }
 
 TrackObjectPtr TrackManager::get_dummy(const int a_idx) const {
-    // first check that we're trying to get a dummy object (ID should be neg)
-    assert(a_idx < 0);
-    assert(!m_dummies.empty());
+  // first check that we're trying to get a dummy object (ID should be neg)
+  assert(a_idx < 0);
+  assert(!m_dummies.empty());
 
-    unsigned int dummy_idx = std::abs(a_idx + 1);
+  unsigned int dummy_idx = std::abs(a_idx + 1);
 
-    // sanity check that we've actually got a dummy
-    assert(m_dummies[dummy_idx]->dummy);
+  // sanity check that we've actually got a dummy
+  assert(m_dummies[dummy_idx]->dummy);
 
-    // return the dummies
-    return m_dummies[dummy_idx];
+  // return the dummies
+  return m_dummies[dummy_idx];
 }

--- a/btrack/src/motion.cc
+++ b/btrack/src/motion.cc
@@ -19,63 +19,55 @@
 MotionModel::MotionModel(const Eigen::MatrixXd &A, const Eigen::MatrixXd &H,
                          const Eigen::MatrixXd &P, const Eigen::MatrixXd &R,
                          const Eigen::MatrixXd &Q)
-    : A(A),
-      H(H),
-      P(P),
-      R(R),
-      Q(Q),
-      measurements(H.rows()),
-      states(A.rows()),
-      x_hat(states),
-      x_hat_new(states),
-      I(states, states) {
-    // set the time step and the identity matrix used by the Kalman filter
-    dt = 1;
-    I.setIdentity();
+    : A(A), H(H), P(P), R(R), Q(Q), measurements(H.rows()), states(A.rows()),
+      x_hat(states), x_hat_new(states), I(states, states) {
+  // set the time step and the identity matrix used by the Kalman filter
+  dt = 1;
+  I.setIdentity();
 
-    // fill the current prediction and motion vector with zeros
-    x_hat.fill(0.0);
-    motion_vector.fill(0.0);
+  // fill the current prediction and motion vector with zeros
+  x_hat.fill(0.0);
+  motion_vector.fill(0.0);
 
-    // set an initialised flag
-    initialised = true;
+  // set an initialised flag
+  initialised = true;
 }
 
 // setup with a new observation
 // DONE(arl): make this agnostic to model
 void MotionModel::setup(const TrackObjectPtr new_object) {
-    x_hat.head(3) = new_object->position();
+  x_hat.head(3) = new_object->position();
 };
 
 // return a prediction of the position and (co)variance
 Prediction MotionModel::predict() const {
-    assert(initialised);
-    Prediction p = Prediction(x_hat, P);
-    return p;
+  assert(initialised);
+  Prediction p = Prediction(x_hat, P);
+  return p;
 }
 
 // update the model with a new observation or dummy
 void MotionModel::update(const TrackObjectPtr new_object) {
-    assert(initialised);
+  assert(initialised);
 
-    // discrete Kalman filter time update, no control...
-    x_hat_new = A * x_hat;
-    P = A * P * A.transpose() + Q;
+  // discrete Kalman filter time update, no control...
+  x_hat_new = A * x_hat;
+  P = A * P * A.transpose() + Q;
 
-    // if this is a dummy object, end here. Update prediction without new data
-    if (new_object->dummy) {
-        x_hat = x_hat_new;
-        return;
-    }
-
-    // kalman gain and the measurement update
-    K = P * H.transpose() * (H * P * H.transpose() + R).inverse();
-    x_hat_new = x_hat_new + K * (new_object->position() - H * x_hat_new);
-
-    // update the motion vector, essentially the difference in position
-    motion_vector = x_hat_new.head(3) - x_hat.head(3);
-
-    // update P and the predicted state
-    P = (I - K * H) * P;
+  // if this is a dummy object, end here. Update prediction without new data
+  if (new_object->dummy) {
     x_hat = x_hat_new;
+    return;
+  }
+
+  // kalman gain and the measurement update
+  K = P * H.transpose() * (H * P * H.transpose() + R).inverse();
+  x_hat_new = x_hat_new + K * (new_object->position() - H * x_hat_new);
+
+  // update the motion vector, essentially the difference in position
+  motion_vector = x_hat_new.head(3) - x_hat.head(3);
+
+  // update P and the predicted state
+  P = (I - K * H) * P;
+  x_hat = x_hat_new;
 }

--- a/btrack/src/pdf.cc
+++ b/btrack/src/pdf.cc
@@ -23,78 +23,78 @@ using namespace ProbabilityDensityFunctions;
 // http://cs229.stanford.edu/section/gaussians.pdf
 
 double ProbabilityDensityFunctions::cheat_multivariate_normal(
-    const TrackletPtr& trk, const TrackObjectPtr& obj) {
-    Prediction p = trk->predict();
-    Eigen::Vector3d x = obj->position();
+    const TrackletPtr &trk, const TrackObjectPtr &obj) {
+  Prediction p = trk->predict();
+  Eigen::Vector3d x = obj->position();
 
-    double prob_density =
+  double prob_density =
 
-        (1. / (kRootTwoPi * sqrt(p.covar(0, 0)))) *
-        exp(-(1. / (2. * p.covar(0, 0))) * (x(0) - p.mu(0)) *
-            (x(0) - p.mu(0))) *
-        (1. / (kRootTwoPi * sqrt(p.covar(1, 1)))) *
-        exp(-(1. / (2. * p.covar(1, 1))) * (x(1) - p.mu(1)) *
-            (x(1) - p.mu(1))) *
-        (1. / (kRootTwoPi * sqrt(p.covar(2, 2)))) *
-        exp(-(1. / (2. * p.covar(2, 2))) * (x(2) - p.mu(2)) * (x(2) - p.mu(2)));
+      (1. / (kRootTwoPi * sqrt(p.covar(0, 0)))) *
+      exp(-(1. / (2. * p.covar(0, 0))) * (x(0) - p.mu(0)) * (x(0) - p.mu(0))) *
+      (1. / (kRootTwoPi * sqrt(p.covar(1, 1)))) *
+      exp(-(1. / (2. * p.covar(1, 1))) * (x(1) - p.mu(1)) * (x(1) - p.mu(1))) *
+      (1. / (kRootTwoPi * sqrt(p.covar(2, 2)))) *
+      exp(-(1. / (2. * p.covar(2, 2))) * (x(2) - p.mu(2)) * (x(2) - p.mu(2)));
 
-    return prob_density;
+  return prob_density;
 }
 
 // also we need to calculate the probability (the integral), so we use erf
 // http://en.cppreference.com/w/cpp/numeric/math/erf
 
-double ProbabilityDensityFunctions::multivariate_erf(
-    const TrackletPtr& trk, const TrackObjectPtr& obj,
-    const double accuracy = 2.) {
-    Prediction p = trk->predict();
-    Eigen::Vector3d x = obj->position();
+double
+ProbabilityDensityFunctions::multivariate_erf(const TrackletPtr &trk,
+                                              const TrackObjectPtr &obj,
+                                              const double accuracy = 2.) {
+  Prediction p = trk->predict();
+  Eigen::Vector3d x = obj->position();
 
-    double phi = 1.;
-    double phi_x, std_x, d_x;
+  double phi = 1.;
+  double phi_x, std_x, d_x;
 
-    for (unsigned int axis = 0; axis < 3; axis++) {
-        std_x = std::sqrt(p.covar(axis, axis));
-        d_x = x(axis) - p.mu(axis);
+  for (unsigned int axis = 0; axis < 3; axis++) {
+    std_x = std::sqrt(p.covar(axis, axis));
+    d_x = x(axis) - p.mu(axis);
 
-        // intergral +/- accuracy
-        phi_x = std::erf((d_x + accuracy) / (std_x * kRootTwo)) -
-                std::erf((d_x - accuracy) / (std_x * kRootTwo));
+    // intergral +/- accuracy
+    phi_x = std::erf((d_x + accuracy) / (std_x * kRootTwo)) -
+            std::erf((d_x - accuracy) / (std_x * kRootTwo));
 
-        // calculate product of integrals for the axes i.e. joint probability?
-        phi *= .5 * phi_x;
-    }
+    // calculate product of integrals for the axes i.e. joint probability?
+    phi *= .5 * phi_x;
+  }
 
-    // we don't want a NaN!
-    assert(!std::isnan(phi));
+  // we don't want a NaN!
+  assert(!std::isnan(phi));
 
-    return phi;
+  return phi;
 }
 
 // cosine similarity
-double ProbabilityDensityFunctions::cosine_similarity(
-    const TrackletPtr& trk, const TrackObjectPtr& obj) {
-    TrackObjectPtr trk_last = trk->track.back();
+double
+ProbabilityDensityFunctions::cosine_similarity(const TrackletPtr &trk,
+                                               const TrackObjectPtr &obj) {
+  TrackObjectPtr trk_last = trk->track.back();
 
-    // calculate cosine similarity between two feature vectors
-    double f_dot = trk_last->features.dot(obj->features);
-    double f_mag = (trk_last->features).norm() * (obj->features).norm();
-    double cosine_similarity = f_dot / f_mag;
+  // calculate cosine similarity between two feature vectors
+  double f_dot = trk_last->features.dot(obj->features);
+  double f_mag = (trk_last->features).norm() * (obj->features).norm();
+  double cosine_similarity = f_dot / f_mag;
 
-    if (!(cosine_similarity >= -1.0 && cosine_similarity <= 1.0)) {
-        if (DEBUG) {
-            std::cout << cosine_similarity;
-            std::cout << " f_dot: " << f_dot;
-            std::cout << " f_mag: " << f_mag;
-            std::cout << " trk_features: " << (trk_last->features);
-            std::cout << " obj_features: " << (obj->features);
-            std::cout << std::endl;
-        }
-
-        // return a default value
-        cosine_similarity = 0.0;
+  if (!(cosine_similarity >= -1.0 && cosine_similarity <= 1.0)) {
+    if (DEBUG) {
+      std::cout << cosine_similarity;
+      std::cout << " f_dot: " << f_dot;
+      std::cout << " f_mag: " << f_mag;
+      std::cout << " trk_features: " << (trk_last->features);
+      std::cout << " obj_features: " << (obj->features);
+      std::cout << std::endl;
     }
 
-    // rescale to 0.0-1.0
-    return (cosine_similarity + 1.0) / 2.0;
+    // return a default value
+    cosine_similarity = 0.0;
+  }
+
+  // rescale to 0.0-1.0
+  return (cosine_similarity + 1.0) / 2.0;
 }

--- a/btrack/src/tracker.cc
+++ b/btrack/src/tracker.cc
@@ -21,513 +21,515 @@ using namespace BayesianUpdateFunctions;
 
 void write_belief_matrix_to_CSV(std::string a_filename,
                                 Eigen::Ref<Eigen::MatrixXd> a_belief) {
-    std::cout << "Writing: " << a_filename << std::endl;
-    std::ofstream belief_file;
-    belief_file.open(a_filename);
-    belief_file << a_belief.format(CSVFormat);
-    belief_file.close();
+  std::cout << "Writing: " << a_filename << std::endl;
+  std::ofstream belief_file;
+  belief_file.open(a_filename);
+  belief_file << a_belief.format(CSVFormat);
+  belief_file.close();
 }
 
 // set up the tracker using an existing track manager
 BayesianTracker::BayesianTracker(const bool verbose,
                                  const unsigned int update_mode,
-                                 TrackManager* a_manager) {
-    // set up verbosity
-    this->verbose = verbose;
+                                 TrackManager *a_manager) {
+  // set up verbosity
+  this->verbose = verbose;
 
-    // set up the tracks
-    this->manager = a_manager;
+  // set up the tracks
+  this->manager = a_manager;
 
-    // NOTE(arl): This isn't really necessary
-    // set up the frame map
-    frames.clear();
+  // NOTE(arl): This isn't really necessary
+  // set up the frame map
+  frames.clear();
 
-    // set the current frame to zero
-    current_frame = 0;
+  // set the current frame to zero
+  current_frame = 0;
 
-    // reserve some space for the tracks
-    active.reserve(RESERVE_ACTIVE_TRACKS);
-    new_objects.reserve(RESERVE_NEW_OBJECTS);
+  // reserve some space for the tracks
+  active.reserve(RESERVE_ACTIVE_TRACKS);
+  new_objects.reserve(RESERVE_NEW_OBJECTS);
 
-    // set the appropriate cost function
-    set_update_mode(update_mode);
+  // set the appropriate cost function
+  set_update_mode(update_mode);
 
-    // set a outputfile path
-    // define a filepath for debugging output
-    if (WRITE_BELIEF_MATRIX) {
-        m_debug_filepath = std::filesystem::temp_directory_path();
-        std::cout << "Using temp file path: " << m_debug_filepath << std::endl;
-    }
+  // set a outputfile path
+  // define a filepath for debugging output
+  if (WRITE_BELIEF_MATRIX) {
+    m_debug_filepath = std::filesystem::temp_directory_path();
+    std::cout << "Using temp file path: " << m_debug_filepath << std::endl;
+  }
 }
 
 BayesianTracker::~BayesianTracker() {
-    // std::cout << "Destruction of BayesianTracker" << std::endl;
-    //  clean up gracefully
+  // std::cout << "Destruction of BayesianTracker" << std::endl;
+  //  clean up gracefully
 }
 
 void BayesianTracker::set_update_mode(const unsigned int update_mode) {
-    cost_function_mode = update_mode;
-    if (DEBUG) std::cout << "Update mode: " << cost_function_mode << std::endl;
+  cost_function_mode = update_mode;
+  if (DEBUG)
+    std::cout << "Update mode: " << cost_function_mode << std::endl;
 
-    if (cost_function_mode == UPDATE_MODE_EXACT) {
-        m_cost_fn = &BayesianTracker::cost_EXACT;
-    } else if (cost_function_mode == UPDATE_MODE_APPROXIMATE) {
-        m_cost_fn = &BayesianTracker::cost_APPROXIMATE;
-    } else {
-        // throw std::runtime_error("CUDA update method not supported");
+  if (cost_function_mode == UPDATE_MODE_EXACT) {
+    m_cost_fn = &BayesianTracker::cost_EXACT;
+  } else if (cost_function_mode == UPDATE_MODE_APPROXIMATE) {
+    m_cost_fn = &BayesianTracker::cost_APPROXIMATE;
+  } else {
+    // throw std::runtime_error("CUDA update method not supported");
 
-        std::cout << "CUDA update method not currently supported, reverting to "
-                     "EXACT.";
-        std::cout << std::endl;
+    std::cout << "CUDA update method not currently supported, reverting to "
+                 "EXACT.";
+    std::cout << std::endl;
 
-        m_cost_fn = &BayesianTracker::cost_EXACT;
-    }
+    m_cost_fn = &BayesianTracker::cost_EXACT;
+  }
 }
 
 unsigned int BayesianTracker::set_motion_model(
-    const unsigned int measurements, const unsigned int states, double* A_raw,
-    double* H_raw, double* P_raw, double* Q_raw, double* R_raw, const double dt,
+    const unsigned int measurements, const unsigned int states, double *A_raw,
+    double *H_raw, double *P_raw, double *Q_raw, double *R_raw, const double dt,
     const double accuracy, const unsigned int max_lost,
     const double prob_not_assign) {
-    // do some error checking
-    if (prob_not_assign <= 0. || prob_not_assign >= 1.)
-        return ERROR_prob_not_assign_out_of_range;
+  // do some error checking
+  if (prob_not_assign <= 0. || prob_not_assign >= 1.)
+    return ERROR_prob_not_assign_out_of_range;
 
-    if (max_lost > 10) return ERROR_max_lost_out_of_range;
+  if (max_lost > 10)
+    return ERROR_max_lost_out_of_range;
 
-    if (accuracy < 0. || accuracy > 10.) return ERROR_accuracy_out_of_range;
+  if (accuracy < 0. || accuracy > 10.)
+    return ERROR_accuracy_out_of_range;
 
-    this->max_lost = max_lost;
-    this->prob_not_assign = prob_not_assign;
-    this->accuracy = accuracy;
+  this->max_lost = max_lost;
+  this->prob_not_assign = prob_not_assign;
+  this->accuracy = accuracy;
 
-    if (verbose && DEBUG) {
-        std::cout << "MAX_LOST: " << this->max_lost << std::endl;
-        std::cout << "ACCURACY: " << this->accuracy << std::endl;
-        std::cout << "PROB_NOT_ASSIGN: " << this->prob_not_assign << std::endl;
-    }
+  if (verbose && DEBUG) {
+    std::cout << "MAX_LOST: " << this->max_lost << std::endl;
+    std::cout << "ACCURACY: " << this->accuracy << std::endl;
+    std::cout << "PROB_NOT_ASSIGN: " << this->prob_not_assign << std::endl;
+  }
 
-    typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-                          Eigen::RowMajor>
-        RowMajMat;
+  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+      RowMajMat;
 
-    // map the arrays to Eigen matrices
-    Eigen::MatrixXd H = Eigen::Map<RowMajMat>(H_raw, measurements, states);
-    Eigen::MatrixXd Q = Eigen::Map<RowMajMat>(Q_raw, states, states);
-    Eigen::MatrixXd P = Eigen::Map<RowMajMat>(P_raw, states, states);
-    Eigen::MatrixXd R =
-        Eigen::Map<RowMajMat>(R_raw, measurements, measurements);
-    Eigen::MatrixXd A = Eigen::Map<RowMajMat>(A_raw, states, states);
+  // map the arrays to Eigen matrices
+  Eigen::MatrixXd H = Eigen::Map<RowMajMat>(H_raw, measurements, states);
+  Eigen::MatrixXd Q = Eigen::Map<RowMajMat>(Q_raw, states, states);
+  Eigen::MatrixXd P = Eigen::Map<RowMajMat>(P_raw, states, states);
+  Eigen::MatrixXd R = Eigen::Map<RowMajMat>(R_raw, measurements, measurements);
+  Eigen::MatrixXd A = Eigen::Map<RowMajMat>(A_raw, states, states);
 
-    // set up a new motion model
-    motion_model = MotionModel(A, H, P, R, Q);
+  // set up a new motion model
+  motion_model = MotionModel(A, H, P, R, Q);
 
-    return SUCCESS;
+  return SUCCESS;
 }
 
-unsigned int BayesianTracker::append(const PyTrackObject& new_object) {
-    // take a vector of TrackObjects as input and perform the tracking step
+unsigned int BayesianTracker::append(const PyTrackObject &new_object) {
+  // take a vector of TrackObjects as input and perform the tracking step
 
-    // from the PyTrackObject create a track object with a shared pointer.
-    // This will be stored
-    TrackObjectPtr p = std::make_shared<TrackObject>(new_object);
+  // from the PyTrackObject create a track object with a shared pointer.
+  // This will be stored
+  TrackObjectPtr p = std::make_shared<TrackObject>(new_object);
 
-    // NOTE: THIS IS PROBABLY UNNECESSARY UNTIL WE RETURN PyTrackObjects...
-    // p->original_object = &new_object;
-    // std::cout << "features: " << p->features << std::endl;
+  // NOTE: THIS IS PROBABLY UNNECESSARY UNTIL WE RETURN PyTrackObjects...
+  // p->original_object = &new_object;
+  // std::cout << "features: " << p->features << std::endl;
 
-    // update the imaging volume with this new measurement
-    volume.update(p);
+  // update the imaging volume with this new measurement
+  volume.update(p);
 
-    // add a new object and maintain a set of frame numbers...
-    // objects.push_back( p );
-    manager->push_node(p);
-    frames_set.insert(p->t);
+  // add a new object and maintain a set of frame numbers...
+  // objects.push_back( p );
+  manager->push_node(p);
+  frames_set.insert(p->t);
 
-    // set this flag to true
-    // initialised = true;
-    return SUCCESS;
+  // set this flag to true
+  // initialised = true;
+  return SUCCESS;
 }
 
 // track all objects
 void BayesianTracker::track_all() {
-    if (statistics.complete) {
-        statistics.error = ERROR_no_tracks;
-    }
+  if (statistics.complete) {
+    statistics.error = ERROR_no_tracks;
+  }
 
-    // iterate over the whole set
-    while (!statistics.complete) {
-        step();
-    }
+  // iterate over the whole set
+  while (!statistics.complete) {
+    step();
+  }
 }
 
 // initialise the first frame
 unsigned int BayesianTracker::initialise() {
-    // if we have already initialised, return early
-    if (initialised) return SUCCESS;
-
-    if (DEBUG) {
-        std::cout << "Using motion features: " << use_motion_features()
-                  << std::endl;
-        std::cout << "Using visual features: " << use_visual_features()
-                  << std::endl;
-    }
-
-    // check to make sure that we've got some objects to track
-    if (manager->num_nodes() < 1) {
-        if (verbose) {
-            std::cout << "Object queue is empty. " << std::endl;
-        }
-        return ERROR_empty_queue;
-    }
-
-    if (manager->num_tracks() > 0) {
-        if (verbose) {
-            std::cout << "Tracking has already been performed. " << std::endl;
-        }
-        return ERROR_no_tracks;
-    }
-
-    // // sort the objects vector by time
-    // std::sort( objects.begin(), objects.end(), compare_obj_time );
-    manager->sort_nodes();
-
-    // NOTE: should check that we have some frames which can be tracked
-    // start by converting the set to a vector
-    std::vector<unsigned int> f(frames_set.begin(), frames_set.end());
-    frames = f;
-
-    bool useable_frames = false;
-    for (size_t n = 1; n < frames.size(); n++) {
-        if ((frames[n] - frames[n - 1]) <= max_lost) {
-            useable_frames = true;
-            continue;
-        }
-    }
-
-    if (!useable_frames) {
-        if (verbose) {
-            std::cout << "No trackable frames have been found. " << std::endl;
-        }
-        return ERROR_no_useable_frames;
-    }
-
-    if (verbose && DEBUG) {
-        std::cout << "FRAME RANGE: " << frames.front() << "-" << frames.back();
-        std::cout << std::endl;
-    }
-
-    // get the number of objects and a counter to the first object
-    n_objects = manager->num_nodes();
-    o_counter = 0;
-
-    // set the current frame of the tracker
-    current_frame = frames.front();
-
-    // set up the first tracklets based on the first set of objects
-    while (manager->get_node(o_counter)->t == current_frame &&
-           o_counter != n_objects - 1) {
-        // add a new tracklet
-        TrackletPtr trk = std::make_shared<Tracklet>(
-            get_new_ID(),
-            manager->get_node(o_counter),  // objects[o_counter],
-            max_lost, this->motion_model);
-        // tracks.push_back( trk );
-        manager->push_track(trk);
-        o_counter++;
-    }
-
-    // add one to the iteration
-    current_frame++;
-
-    // set the initialised flag
-    initialised = true;
-
+  // if we have already initialised, return early
+  if (initialised)
     return SUCCESS;
+
+  if (DEBUG) {
+    std::cout << "Using motion features: " << use_motion_features()
+              << std::endl;
+    std::cout << "Using visual features: " << use_visual_features()
+              << std::endl;
+  }
+
+  // check to make sure that we've got some objects to track
+  if (manager->num_nodes() < 1) {
+    if (verbose) {
+      std::cout << "Object queue is empty. " << std::endl;
+    }
+    return ERROR_empty_queue;
+  }
+
+  if (manager->num_tracks() > 0) {
+    if (verbose) {
+      std::cout << "Tracking has already been performed. " << std::endl;
+    }
+    return ERROR_no_tracks;
+  }
+
+  // // sort the objects vector by time
+  // std::sort( objects.begin(), objects.end(), compare_obj_time );
+  manager->sort_nodes();
+
+  // NOTE: should check that we have some frames which can be tracked
+  // start by converting the set to a vector
+  std::vector<unsigned int> f(frames_set.begin(), frames_set.end());
+  frames = f;
+
+  bool useable_frames = false;
+  for (size_t n = 1; n < frames.size(); n++) {
+    if ((frames[n] - frames[n - 1]) <= max_lost) {
+      useable_frames = true;
+      continue;
+    }
+  }
+
+  if (!useable_frames) {
+    if (verbose) {
+      std::cout << "No trackable frames have been found. " << std::endl;
+    }
+    return ERROR_no_useable_frames;
+  }
+
+  if (verbose && DEBUG) {
+    std::cout << "FRAME RANGE: " << frames.front() << "-" << frames.back();
+    std::cout << std::endl;
+  }
+
+  // get the number of objects and a counter to the first object
+  n_objects = manager->num_nodes();
+  o_counter = 0;
+
+  // set the current frame of the tracker
+  current_frame = frames.front();
+
+  // set up the first tracklets based on the first set of objects
+  while (manager->get_node(o_counter)->t == current_frame &&
+         o_counter != n_objects - 1) {
+    // add a new tracklet
+    TrackletPtr trk = std::make_shared<Tracklet>(
+        get_new_ID(),
+        manager->get_node(o_counter), // objects[o_counter],
+        max_lost, this->motion_model);
+    // tracks.push_back( trk );
+    manager->push_track(trk);
+    o_counter++;
+  }
+
+  // add one to the iteration
+  current_frame++;
+
+  // set the initialised flag
+  initialised = true;
+
+  return SUCCESS;
 }
 
 // update the tracker by some number of steps
 void BayesianTracker::step(const unsigned int steps) {
-    // make sure that we have steps greater than zero
-    // assert(steps>0);
-    if (steps < 1) return;
+  // make sure that we have steps greater than zero
+  // assert(steps>0);
+  if (steps < 1)
+    return;
 
-    // reset the step counter
-    unsigned int step = 0;
+  // reset the step counter
+  unsigned int step = 0;
 
-    // first check the iteration, if it is zero, initialise
-    // TODO(arl): we don't necessarily start on frame zero?
-    // if (current_frame == 0) {
-    if (!initialised) {
-        // initialise!
-        unsigned int ret = initialise();
-        if (ret != SUCCESS) {
-            // return the error in a statistics structure
-            statistics.error = ret;
-            return;
+  // first check the iteration, if it is zero, initialise
+  // TODO(arl): we don't necessarily start on frame zero?
+  // if (current_frame == 0) {
+  if (!initialised) {
+    // initialise!
+    unsigned int ret = initialise();
+    if (ret != SUCCESS) {
+      // return the error in a statistics structure
+      statistics.error = ret;
+      return;
+    }
+    // take a step
+    // step++;
+  }
+
+  while (step < steps && current_frame <= frames.back()) {
+    // update the list of active tracks
+    update_active();
+
+    // clear the list of objects
+    new_objects.clear();
+
+    // std::cout << "Full Frame: " << current_frame << std::endl;
+
+    // loop over all tracks found in this frame
+    if (o_counter < n_objects) {
+      while (manager->get_node(o_counter)->t == current_frame) {
+        // store a reference to this object
+        new_objects.push_back(manager->get_node(o_counter));
+        o_counter++;
+
+        // make sure our iterator doesn't run off the end of the vector
+        if (o_counter >= n_objects) {
+          break;
         }
-        // take a step
-        // step++;
+      }
     }
 
-    while (step < steps && current_frame <= frames.back()) {
-        // update the list of active tracks
-        update_active();
+    // set up some counters
+    size_t n_active = active.size();
+    size_t n_obs = new_objects.size();
 
-        // clear the list of objects
-        new_objects.clear();
-
-        // std::cout << "Full Frame: " << current_frame << std::endl;
-
-        // loop over all tracks found in this frame
-        if (o_counter < n_objects) {
-            while (manager->get_node(o_counter)->t == current_frame) {
-                // store a reference to this object
-                new_objects.push_back(manager->get_node(o_counter));
-                o_counter++;
-
-                // make sure our iterator doesn't run off the end of the vector
-                if (o_counter >= n_objects) {
-                    break;
-                }
-            }
-        }
-
-        // set up some counters
-        size_t n_active = active.size();
-        size_t n_obs = new_objects.size();
-
-        // if we have an empty frame, append dummies to everthing and continue
-        if (new_objects.empty()) {
-            // std::cout << "Frame " << current_frame << " is empty..." <<
-            // std::endl;
-            for (size_t i = 0; i < n_active; i++) {
-                active[i]->append_dummy(use_motion_features());
-            }
-            step++;
-            current_frame++;
-            continue;
-        }
-
-        // make some space for the belief matrix
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> belief;
-
-        // now do the Bayesian updates
-        belief.setZero(n_obs + 1, n_active);
-
-        // set the update iteration
-        // on the first pass, use a uniform prior
-        // on the second pass, use the current prior and so forth
-        unsigned int update_iteration = 0;
-
-        // now do the Bayesian updates using the correct mode
-        // use an implicit function pointer call to the appropriate cost
-        // function
-        if (use_motion_features()) {
-            m_update_fn = &BayesianTracker::prob_update_motion;
-            (this->*m_cost_fn)(belief, n_active, n_obs,
-                               (update_iteration == USE_UNIFORM_PRIOR));
-            update_iteration++;
-        }
-
-        if (use_visual_features()) {
-            m_update_fn = &BayesianTracker::prob_update_visual;
-            (this->*m_cost_fn)(belief, n_active, n_obs,
-                               (update_iteration == USE_UNIFORM_PRIOR));
-            update_iteration++;
-        }
-
-        // write out belief matrix here
-        if (WRITE_BELIEF_MATRIX) {
-            std::stringstream belief_filename;
-            belief_filename << m_debug_filepath << "belief_" << current_frame
-                            << ".csv";
-            write_belief_matrix_to_CSV(belief_filename.str(), belief);
-        }
-
-        // if we're storing the graph edges for future optimization, do so here
-        // this should be done *BEFORE* linking because it relies on the
-        // unlinked tracks to store the original hypothesis
-        if (manager->get_store_candidate_graph()) {
-            for (size_t trk = 0; trk < n_active; trk++) {
-                Eigen::VectorXd prob_assign_per_obj;
-                prob_assign_per_obj = belief.col(trk);
-
-                // if we are lost, don't store the edge, it will be generated
-                // later by the optimizer
-                Eigen::MatrixXf::Index best_candidate;
-                double prob = prob_assign_per_obj.maxCoeff(&best_candidate);
-                if (int(best_candidate) == n_obs) continue;
-
-                // note that this doesn't store an edge to `lost`, but we can
-                // infer it as 1 - sum(scores) for each association
-                for (size_t obj = 0; obj < n_obs; obj++) {
-                    manager->push_edge(
-                        active[trk]->track.back(), new_objects[obj],
-                        prob_assign_per_obj[obj], GRAPH_EDGE_link);
-                }
-            }
-        }
-
-        // now that we have the complete belief matrix, we want to associate
-        // do naive linking
-        link(belief, n_active, n_obs);
-
-        // update the iteration counter
-        step++;
-        current_frame++;
+    // if we have an empty frame, append dummies to everthing and continue
+    if (new_objects.empty()) {
+      // std::cout << "Frame " << current_frame << " is empty..." <<
+      // std::endl;
+      for (size_t i = 0; i < n_active; i++) {
+        active[i]->append_dummy(use_motion_features());
+      }
+      step++;
+      current_frame++;
+      continue;
     }
 
-    // have we finished?
-    if (current_frame >= frames.back()) {
-        statistics.complete = true;
-        // clean();
-        manager->finalise();
+    // make some space for the belief matrix
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> belief;
+
+    // now do the Bayesian updates
+    belief.setZero(n_obs + 1, n_active);
+
+    // set the update iteration
+    // on the first pass, use a uniform prior
+    // on the second pass, use the current prior and so forth
+    unsigned int update_iteration = 0;
+
+    // now do the Bayesian updates using the correct mode
+    // use an implicit function pointer call to the appropriate cost
+    // function
+    if (use_motion_features()) {
+      m_update_fn = &BayesianTracker::prob_update_motion;
+      (this->*m_cost_fn)(belief, n_active, n_obs,
+                         (update_iteration == USE_UNIFORM_PRIOR));
+      update_iteration++;
     }
 
-    // return statistics;
+    if (use_visual_features()) {
+      m_update_fn = &BayesianTracker::prob_update_visual;
+      (this->*m_cost_fn)(belief, n_active, n_obs,
+                         (update_iteration == USE_UNIFORM_PRIOR));
+      update_iteration++;
+    }
+
+    // write out belief matrix here
+    if (WRITE_BELIEF_MATRIX) {
+      std::stringstream belief_filename;
+      belief_filename << m_debug_filepath << "belief_" << current_frame
+                      << ".csv";
+      write_belief_matrix_to_CSV(belief_filename.str(), belief);
+    }
+
+    // if we're storing the graph edges for future optimization, do so here
+    // this should be done *BEFORE* linking because it relies on the
+    // unlinked tracks to store the original hypothesis
+    if (manager->get_store_candidate_graph()) {
+      for (size_t trk = 0; trk < n_active; trk++) {
+        Eigen::VectorXd prob_assign_per_obj;
+        prob_assign_per_obj = belief.col(trk);
+
+        // if we are lost, don't store the edge, it will be generated
+        // later by the optimizer
+        Eigen::MatrixXf::Index best_candidate;
+        double prob = prob_assign_per_obj.maxCoeff(&best_candidate);
+        if (int(best_candidate) == n_obs)
+          continue;
+
+        // note that this doesn't store an edge to `lost`, but we can
+        // infer it as 1 - sum(scores) for each association
+        for (size_t obj = 0; obj < n_obs; obj++) {
+          manager->push_edge(active[trk]->track.back(), new_objects[obj],
+                             prob_assign_per_obj[obj], GRAPH_EDGE_link);
+        }
+      }
+    }
+
+    // now that we have the complete belief matrix, we want to associate
+    // do naive linking
+    link(belief, n_active, n_obs);
+
+    // update the iteration counter
+    step++;
+    current_frame++;
+  }
+
+  // have we finished?
+  if (current_frame >= frames.back()) {
+    statistics.complete = true;
+    // clean();
+    manager->finalise();
+  }
+
+  // return statistics;
 }
 
 bool BayesianTracker::update_active() {
-    // TODO: MAKE INTERMEDIATE LIST OF TRACKS TO MINIMISE LOOPING OVER
-    // EVERYTHING
+  // TODO: MAKE INTERMEDIATE LIST OF TRACKS TO MINIMISE LOOPING OVER
+  // EVERYTHING
 
-    // clear the active list
-    active.clear();
+  // clear the active list
+  active.clear();
 
-    for (size_t i = 0, trks_size = manager->num_tracks(); i < trks_size; i++) {
-        TrackletPtr trk = manager->get_track(i);
+  for (size_t i = 0, trks_size = manager->num_tracks(); i < trks_size; i++) {
+    TrackletPtr trk = manager->get_track(i);
 
-        // check to see whether we have exceeded the bounds
-        if (!volume.inside(trk->position())) {
-            trk->set_lost();
-            continue;
-        }
-
-        // if the track is still active, add it to the update list
-        if (trk->active()) {
-            active.push_back(trk);
-        } else {
-            trk->trim();  // remove dummies if this track is lost
-        }
+    // check to see whether we have exceeded the bounds
+    if (!volume.inside(trk->position())) {
+      trk->set_lost();
+      continue;
     }
 
-    return true;
+    // if the track is still active, add it to the update list
+    if (trk->active()) {
+      active.push_back(trk);
+    } else {
+      trk->trim(); // remove dummies if this track is lost
+    }
+  }
+
+  return true;
 }
 
 void BayesianTracker::debug_output(const unsigned int frm) const {
-    // std::cout << "Tracking objects in Frames " << frm-100 << "-" << frm;
-    // std::cout << "... " << std::endl;
-    // std::cout << " > Currently tracking " << active.size();
-    // std::cout << " objects..." << std::endl;
-    // std::cout << " - Lost " << num_lost << " tracks for greater than ";
-    // std::cout << max_lost << " frames. Removing..." << std::endl;
-    // std::cout << " + Started " << tracks.size()-active.size();
-    // std::cout << " new tracklets..." << std::endl;
-    // std::cout << " ~ Found " << num_conflicts << " conflicts..." <<
-    // std::endl;
+  // std::cout << "Tracking objects in Frames " << frm-100 << "-" << frm;
+  // std::cout << "... " << std::endl;
+  // std::cout << " > Currently tracking " << active.size();
+  // std::cout << " objects..." << std::endl;
+  // std::cout << " - Lost " << num_lost << " tracks for greater than ";
+  // std::cout << max_lost << " frames. Removing..." << std::endl;
+  // std::cout << " + Started " << tracks.size()-active.size();
+  // std::cout << " new tracklets..." << std::endl;
+  // std::cout << " ~ Found " << num_conflicts << " conflicts..." <<
+  // std::endl;
 }
 
-double BayesianTracker::prob_update_motion(const TrackletPtr& trk,
-                                           const TrackObjectPtr& obj) const {
-    double prob_assign = 0.;
+double BayesianTracker::prob_update_motion(const TrackletPtr &trk,
+                                           const TrackObjectPtr &obj) const {
+  double prob_assign = 0.;
 
-    // calculate the probability that this is the correct track
-    prob_assign =
-        ProbabilityDensityFunctions::multivariate_erf(trk, obj, this->accuracy);
+  // calculate the probability that this is the correct track
+  prob_assign =
+      ProbabilityDensityFunctions::multivariate_erf(trk, obj, this->accuracy);
 
-    // set the probability of assignment to zero if the track is currently
-    // in a metaphase state and the object to link to is anaphase
-    if (DISALLOW_METAPHASE_ANAPHASE_LINKING) {
-        if (trk->track.back()->label == STATE_metaphase &&
-            obj->label == STATE_anaphase) {
-            // set the probability of assignment to zero
-            prob_assign = 0.0;
-        }
+  // set the probability of assignment to zero if the track is currently
+  // in a metaphase state and the object to link to is anaphase
+  if (DISALLOW_METAPHASE_ANAPHASE_LINKING) {
+    if (trk->track.back()->label == STATE_metaphase &&
+        obj->label == STATE_anaphase) {
+      // set the probability of assignment to zero
+      prob_assign = 0.0;
     }
+  }
 
-    // disallow incorrect linking
-    if (DISALLOW_PROMETAPHASE_ANAPHASE_LINKING) {
-        if (trk->track.back()->label == STATE_prometaphase &&
-            obj->label == STATE_anaphase) {
-            // set the probability of assignment to zero
-            prob_assign = 0.0;
-        }
+  // disallow incorrect linking
+  if (DISALLOW_PROMETAPHASE_ANAPHASE_LINKING) {
+    if (trk->track.back()->label == STATE_prometaphase &&
+        obj->label == STATE_anaphase) {
+      // set the probability of assignment to zero
+      prob_assign = 0.0;
     }
+  }
 
-    if (PROB_ASSIGN_EXP_DECAY) {
-        // apply an exponential decay according to number of lost
-        // drops to 50% at max lost
-        double a = std::pow(2, -(double)trk->lost / (double)max_lost);
-        prob_assign = a * prob_assign;
-    }
+  if (PROB_ASSIGN_EXP_DECAY) {
+    // apply an exponential decay according to number of lost
+    // drops to 50% at max lost
+    double a = std::pow(2, -(double)trk->lost / (double)max_lost);
+    prob_assign = a * prob_assign;
+  }
 
-    return prob_assign;
+  return prob_assign;
 }
 
-double BayesianTracker::prob_update_visual(const TrackletPtr& trk,
-                                           const TrackObjectPtr& obj) const {
-    double prob_assign = 0.;
-    prob_assign = ProbabilityDensityFunctions::cosine_similarity(trk, obj);
-    return prob_assign;
+double BayesianTracker::prob_update_visual(const TrackletPtr &trk,
+                                           const TrackObjectPtr &obj) const {
+  double prob_assign = 0.;
+  prob_assign = ProbabilityDensityFunctions::cosine_similarity(trk, obj);
+  return prob_assign;
 }
 
 // make the cost matrix of all possible linkages
 void BayesianTracker::cost_EXACT(Eigen::Ref<Eigen::MatrixXd> belief,
                                  const size_t n_tracks, const size_t n_objects,
                                  const bool use_uniform_prior) {
-    // start a timer
-    std::clock_t t_update_start = std::clock();
+  // start a timer
+  std::clock_t t_update_start = std::clock();
 
-    // set up some variables for Bayesian updates
-    double uniform_prior = 1. / (n_objects + 1);
-    double prior_assign, posterior, safe_update;
+  // set up some variables for Bayesian updates
+  double uniform_prior = 1. / (n_objects + 1);
+  double prior_assign, posterior, safe_update;
 
-    // start by intializing the belief matrix with a uniform prior
-    if (use_uniform_prior) {
-        belief.fill(uniform_prior);
+  // start by intializing the belief matrix with a uniform prior
+  if (use_uniform_prior) {
+    belief.fill(uniform_prior);
+  }
+
+  // Posterior is a misnoma here because it is initially the prior, but
+  // becomes the posterior
+  Eigen::VectorXd v_posterior;
+  Eigen::VectorXd v_update = Eigen::VectorXd(n_objects + 1);
+
+  for (size_t trk = 0; trk != n_tracks; trk++) {
+    // make space for the update
+    // v_posterior = belief.col(trk);
+    v_posterior = belief.col(trk);
+
+    // loop through each candidate object
+    for (size_t obj = 0; obj != n_objects; obj++) {
+      // call the assignment function
+      double prob_assign = (this->*m_update_fn)(active[trk], new_objects[obj]);
+
+      // now do the bayesian updates
+      prior_assign = v_posterior(obj);
+
+      std::tie(safe_update, posterior) =
+          BayesianUpdateFunctions::safe_bayesian_update(
+              prior_assign, prob_assign, prob_not_assign);
+
+      v_update.fill(safe_update);
+      v_update(obj) =
+          1.; // this means the posterior at obj will not be updated?
+
+      // do the update
+      v_posterior = v_posterior.array() * v_update.array();
+      v_posterior(obj) = posterior;
     }
 
-    // Posterior is a misnoma here because it is initially the prior, but
-    // becomes the posterior
-    Eigen::VectorXd v_posterior;
-    Eigen::VectorXd v_update = Eigen::VectorXd(n_objects + 1);
+    // now update the entire column (i.e. track)
+    belief.col(trk) = v_posterior;
+  }
 
-    for (size_t trk = 0; trk != n_tracks; trk++) {
-        // make space for the update
-        // v_posterior = belief.col(trk);
-        v_posterior = belief.col(trk);
-
-        // loop through each candidate object
-        for (size_t obj = 0; obj != n_objects; obj++) {
-            // call the assignment function
-            double prob_assign =
-                (this->*m_update_fn)(active[trk], new_objects[obj]);
-
-            // now do the bayesian updates
-            prior_assign = v_posterior(obj);
-
-            std::tie(safe_update, posterior) =
-                BayesianUpdateFunctions::safe_bayesian_update(
-                    prior_assign, prob_assign, prob_not_assign);
-
-            v_update.fill(safe_update);
-            v_update(obj) =
-                1.;  // this means the posterior at obj will not be updated?
-
-            // do the update
-            v_posterior = v_posterior.array() * v_update.array();
-            v_posterior(obj) = posterior;
-        }
-
-        // now update the entire column (i.e. track)
-        belief.col(trk) = v_posterior;
-    }
-
-    // set the timings
-    double t_elapsed_ms =
-        (std::clock() - t_update_start) / (double)(CLOCKS_PER_SEC / 1000);
-    statistics.t_update_belief = static_cast<float>(t_elapsed_ms);
+  // set the timings
+  double t_elapsed_ms =
+      (std::clock() - t_update_start) / (double)(CLOCKS_PER_SEC / 1000);
+  statistics.t_update_belief = static_cast<float>(t_elapsed_ms);
 }
 
 // make the cost matrix of all possible linkages
@@ -535,240 +537,235 @@ void BayesianTracker::cost_APPROXIMATE(Eigen::Ref<Eigen::MatrixXd> belief,
                                        const size_t n_tracks,
                                        const size_t n_objects,
                                        const bool use_uniform_prior) {
-    // start a timer
-    std::clock_t t_update_start = std::clock();
+  // start a timer
+  std::clock_t t_update_start = std::clock();
 
-    // set up some variables for Bayesian updates
-    double prior_assign, posterior, safe_update;
+  // set up some variables for Bayesian updates
+  double prior_assign, posterior, safe_update;
 
-    // Posterior is a misnoma here because it is initially the prior, but
-    // becomes the posterior
-    Eigen::VectorXd v_posterior;
-    Eigen::VectorXd v_update = Eigen::VectorXd(n_objects + 1);
+  // Posterior is a misnoma here because it is initially the prior, but
+  // becomes the posterior
+  Eigen::VectorXd v_posterior;
+  Eigen::VectorXd v_update = Eigen::VectorXd(n_objects + 1);
 
-    // make a bin map of the objects
-    ObjectBin m_cube = ObjectBin(max_search_radius, 1);
-    for (size_t obj = 0; obj != n_objects; obj++) {
-        m_cube.add_object(new_objects[obj]);
+  // make a bin map of the objects
+  ObjectBin m_cube = ObjectBin(max_search_radius, 1);
+  for (size_t obj = 0; obj != n_objects; obj++) {
+    m_cube.add_object(new_objects[obj]);
+  }
+
+  // iterate over the tracks
+  for (size_t trk = 0; trk != n_tracks; trk++) {
+    // make space for the update
+    // v_posterior = belief.col(trk);
+    v_posterior = belief.col(trk);
+
+    // get the local objects for updating
+    std::vector<TrackObjectPtr_and_Index> local_objects;
+    local_objects = m_cube.get(active[trk], false);
+    size_t n_local_objects = local_objects.size();
+
+    // if there are no local objects, then this track is lost
+    // HOWEVER: only mark as lost if we're assuming no prior information
+    if (n_local_objects < 1 && use_uniform_prior) {
+      v_posterior.fill(0.0);        // all objects have zero probability
+      v_posterior(n_objects) = 1.0; // the lost probability is one
+      belief.col(trk) = v_posterior;
+      continue;
     }
 
-    // iterate over the tracks
-    for (size_t trk = 0; trk != n_tracks; trk++) {
-        // make space for the update
-        // v_posterior = belief.col(trk);
-        v_posterior = belief.col(trk);
+    // TODO(arl):
+    // now that we know which local updates are to be made, approximate all
+    // of the updates that we would have made, set the prior probabilities
+    //
+    // calculate the local uniform prior for only those objects that we have
+    // selected the local objects
 
-        // get the local objects for updating
-        std::vector<TrackObjectPtr_and_Index> local_objects;
-        local_objects = m_cube.get(active[trk], false);
-        size_t n_local_objects = local_objects.size();
+    if (use_uniform_prior) {
+      double local_uniform_prior = 1. / (n_local_objects + 1);
 
-        // if there are no local objects, then this track is lost
-        // HOWEVER: only mark as lost if we're assuming no prior information
-        if (n_local_objects < 1 && use_uniform_prior) {
-            v_posterior.fill(0.0);         // all objects have zero probability
-            v_posterior(n_objects) = 1.0;  // the lost probability is one
-            belief.col(trk) = v_posterior;
-            continue;
-        }
-
-        // TODO(arl):
-        // now that we know which local updates are to be made, approximate all
-        // of the updates that we would have made, set the prior probabilities
-        //
-        // calculate the local uniform prior for only those objects that we have
-        // selected the local objects
-
-        if (use_uniform_prior) {
-            double local_uniform_prior = 1. / (n_local_objects + 1);
-
-            for (size_t obj = 0; obj != n_local_objects; obj++) {
-                v_posterior(local_objects[obj].second) = local_uniform_prior;
-            }
-            // set the lost prior also
-            v_posterior(n_objects) = local_uniform_prior;
-        }
-
-        // loop through each candidate object
-        for (size_t obj = 0; obj != n_local_objects; obj++) {
-            // call the assignment function
-            double prob_assign =
-                (this->*m_update_fn)(active[trk], local_objects[obj].first);
-
-            // now do the bayesian updates
-            prior_assign = v_posterior(local_objects[obj].second);
-
-            std::tie(safe_update, posterior) =
-                BayesianUpdateFunctions::safe_bayesian_update(
-                    prior_assign, prob_assign, prob_not_assign);
-
-            v_update.fill(safe_update);
-
-            // NOTE(arl): Is this necessary?
-            v_update(local_objects[obj].second) =
-                1.;  // this means the posterior at obj will not be updated?
-
-            // do the update
-            v_posterior = v_posterior.array() * v_update.array();
-            v_posterior(local_objects[obj].second) = posterior;
-
-        }  // objects
-
-        // now update the entire column (i.e. track)
-        belief.col(trk) = v_posterior;
+      for (size_t obj = 0; obj != n_local_objects; obj++) {
+        v_posterior(local_objects[obj].second) = local_uniform_prior;
+      }
+      // set the lost prior also
+      v_posterior(n_objects) = local_uniform_prior;
     }
 
-    // set the timings
-    double t_elapsed_ms =
-        (std::clock() - t_update_start) / (double)(CLOCKS_PER_SEC / 1000);
-    statistics.t_update_belief = static_cast<float>(t_elapsed_ms);
+    // loop through each candidate object
+    for (size_t obj = 0; obj != n_local_objects; obj++) {
+      // call the assignment function
+      double prob_assign =
+          (this->*m_update_fn)(active[trk], local_objects[obj].first);
+
+      // now do the bayesian updates
+      prior_assign = v_posterior(local_objects[obj].second);
+
+      std::tie(safe_update, posterior) =
+          BayesianUpdateFunctions::safe_bayesian_update(
+              prior_assign, prob_assign, prob_not_assign);
+
+      v_update.fill(safe_update);
+
+      // NOTE(arl): Is this necessary?
+      v_update(local_objects[obj].second) =
+          1.; // this means the posterior at obj will not be updated?
+
+      // do the update
+      v_posterior = v_posterior.array() * v_update.array();
+      v_posterior(local_objects[obj].second) = posterior;
+
+    } // objects
+
+    // now update the entire column (i.e. track)
+    belief.col(trk) = v_posterior;
+  }
+
+  // set the timings
+  double t_elapsed_ms =
+      (std::clock() - t_update_start) / (double)(CLOCKS_PER_SEC / 1000);
+  statistics.t_update_belief = static_cast<float>(t_elapsed_ms);
 }
 
 // make the cost matrix of all possible linkages
 void BayesianTracker::link(Eigen::Ref<Eigen::MatrixXd> belief,
                            const size_t n_tracks, const size_t n_objects) {
-    // start a timer
-    std::clock_t t_update_start = std::clock();
+  // start a timer
+  std::clock_t t_update_start = std::clock();
 
-    // set up some space for used objects
-    std::set<unsigned int> not_used;
-    for (size_t i = 0; i < n_tracks; i++) {
-        not_used.insert(not_used.end(), i);
+  // set up some space for used objects
+  std::set<unsigned int> not_used;
+  for (size_t i = 0; i < n_tracks; i++) {
+    not_used.insert(not_used.end(), i);
+  }
+
+  // make a track map
+  HypothesisMap<LinkHypothesis> map = HypothesisMap<LinkHypothesis>(n_objects);
+
+  for (size_t trk = 0; trk < n_tracks; trk++) {
+    // get the object with the best match for this track...
+    Eigen::MatrixXf::Index best_object;
+    double prob = belief.col(trk).maxCoeff(&best_object);
+
+    // prevents cases of NaN
+    if (std::isnan(prob)) {
+      prob = 0.0;
     }
 
-    // make a track map
-    HypothesisMap<LinkHypothesis> map =
-        HypothesisMap<LinkHypothesis>(n_objects);
+    // since we're using zero-indexing, n_objects is equivalent to the index
+    // of the last object + 1, i.e. the column for the lost hypothesis...
+    if (int(best_object) != int(n_objects)) {
+      // push this putative linkage to the map
+      map.push(best_object, LinkHypothesis(trk, prob));
 
-    for (size_t trk = 0; trk < n_tracks; trk++) {
-        // get the object with the best match for this track...
-        Eigen::MatrixXf::Index best_object;
-        double prob = belief.col(trk).maxCoeff(&best_object);
+    } else {
+      // this track is probably lost, append a dummy to the trajectory
+      active[trk]->append_dummy(use_motion_features());
+      not_used.erase(trk);
+      n_lost++;
 
-        // prevents cases of NaN
-        if (std::isnan(prob)) {
-            prob = 0.0;
-        }
-
-        // since we're using zero-indexing, n_objects is equivalent to the index
-        // of the last object + 1, i.e. the column for the lost hypothesis...
-        if (int(best_object) != int(n_objects)) {
-            // push this putative linkage to the map
-            map.push(best_object, LinkHypothesis(trk, prob));
-
-        } else {
-            // this track is probably lost, append a dummy to the trajectory
-            active[trk]->append_dummy(use_motion_features());
-            not_used.erase(trk);
-            n_lost++;
-
-            // update the statistics
-            statistics.p_lost = prob;
-        }
+      // update the statistics
+      statistics.p_lost = prob;
     }
+  }
 
-    // now loop through the map
-    for (size_t obj = 0, map_size = map.size(); obj < map_size; obj++) {
-        unsigned int n_links = map[obj].size();
+  // now loop through the map
+  for (size_t obj = 0, map_size = map.size(); obj < map_size; obj++) {
+    unsigned int n_links = map[obj].size();
 
-        // this is a direct correspondence, make the mapping
-        if (n_links == 1) {
-            //  std::cout << map[trk].size() << std::endl;
-            LinkHypothesis lnk = map[obj][0];
+    // this is a direct correspondence, make the mapping
+    if (n_links == 1) {
+      //  std::cout << map[trk].size() << std::endl;
+      LinkHypothesis lnk = map[obj][0];
 
-            unsigned int trk = lnk.first;
+      unsigned int trk = lnk.first;
 
-            if (not_used.count(trk) < 1) {
-                // TODO(arl): make this error more useful
-                std::cout << "ERROR: Exhausted potential linkages."
-                          << std::endl;
-                continue;
-            }
+      if (not_used.count(trk) < 1) {
+        // TODO(arl): make this error more useful
+        std::cout << "ERROR: Exhausted potential linkages." << std::endl;
+        continue;
+      }
 
-            // make sure that we only make links that are possible
-            if (euclidean_dist(active[trk], new_objects[obj]) >
-                    max_search_radius &&
-                CLIP_MAXIMUM_LINKAGE_DISTANCE) {
-                continue;
-            }
+      // make sure that we only make links that are possible
+      if (euclidean_dist(active[trk], new_objects[obj]) > max_search_radius &&
+          CLIP_MAXIMUM_LINKAGE_DISTANCE) {
+        continue;
+      }
 
-            // append the new object onto the track
-            active[trk]->append(new_objects[obj], use_motion_features());
+      // append the new object onto the track
+      active[trk]->append(new_objects[obj], use_motion_features());
 
-            // update the statistics
-            statistics.p_link = lnk.second;
+      // update the statistics
+      statistics.p_link = lnk.second;
 
-            // since we've found a correspondence for this one, remove from set
-            not_used.erase(trk);
+      // since we've found a correspondence for this one, remove from set
+      not_used.erase(trk);
 
-        } else if (n_links < 1) {
-            // this object has no matches, add a new tracklet
-            TrackletPtr trk = std::make_shared<Tracklet>(
-                get_new_ID(), new_objects[obj], max_lost, this->motion_model);
-            // tracks.push_back( trk );
-            manager->push_track(trk);
+    } else if (n_links < 1) {
+      // this object has no matches, add a new tracklet
+      TrackletPtr trk = std::make_shared<Tracklet>(
+          get_new_ID(), new_objects[obj], max_lost, this->motion_model);
+      // tracks.push_back( trk );
+      manager->push_track(trk);
 
 #if !STRICT_TRACKLET_LINKING
-        } else if (n_links > 1) {
-            // conflict, get the best one
-            n_conflicts++;
+    } else if (n_links > 1) {
+      // conflict, get the best one
+      n_conflicts++;
 
-            unsigned int trk;
-            double prob = -1.;
-            for (size_t i = 0; i < n_links; i++) {
-                if (map[obj][i].second > prob) {
-                    prob = map[obj][i].second;
-                    trk = map[obj][i].first;
-                }
-            }
-
-            if (not_used.count(trk) < 1) {
-                // TODO(arl): make this error more useful
-                std::cout << "ERROR: Exhausted potential linkages."
-                          << std::endl;
-                continue;
-            }
-
-            // make sure that we only make links that are possible
-            if (euclidean_dist(active[trk], new_objects[obj]) >
-                    max_search_radius &&
-                CLIP_MAXIMUM_LINKAGE_DISTANCE) {
-                continue;
-            }
-
-            // update only this one
-            active[trk]->append(new_objects[obj], use_motion_features());
-
-            // since we've found a correspondence for this one, remove from set
-            not_used.erase(trk);
-            // */
+      unsigned int trk;
+      double prob = -1.;
+      for (size_t i = 0; i < n_links; i++) {
+        if (map[obj][i].second > prob) {
+          prob = map[obj][i].second;
+          trk = map[obj][i].first;
         }
+      }
+
+      if (not_used.count(trk) < 1) {
+        // TODO(arl): make this error more useful
+        std::cout << "ERROR: Exhausted potential linkages." << std::endl;
+        continue;
+      }
+
+      // make sure that we only make links that are possible
+      if (euclidean_dist(active[trk], new_objects[obj]) > max_search_radius &&
+          CLIP_MAXIMUM_LINKAGE_DISTANCE) {
+        continue;
+      }
+
+      // update only this one
+      active[trk]->append(new_objects[obj], use_motion_features());
+
+      // since we've found a correspondence for this one, remove from set
+      not_used.erase(trk);
+      // */
+    }
 #else
-        }
+    }
 #endif
-    }
+  }
 
-    // get a vector of updates
-    std::vector<unsigned int> to_update(not_used.begin(), not_used.end());
+  // get a vector of updates
+  std::vector<unsigned int> to_update(not_used.begin(), not_used.end());
 
-    for (size_t i = 0, update_size = to_update.size(); i < update_size; i++) {
-        // update these tracks
-        active[to_update[i]]->append_dummy(use_motion_features());
-    }
+  for (size_t i = 0, update_size = to_update.size(); i < update_size; i++) {
+    // update these tracks
+    active[to_update[i]]->append_dummy(use_motion_features());
+  }
 
-    // set the timings
-    double t_elapsed_ms =
-        (std::clock() - t_update_start) / (double)(CLOCKS_PER_SEC / 1000);
-    statistics.t_update_link = static_cast<float>(t_elapsed_ms);
+  // set the timings
+  double t_elapsed_ms =
+      (std::clock() - t_update_start) / (double)(CLOCKS_PER_SEC / 1000);
+  statistics.t_update_link = static_cast<float>(t_elapsed_ms);
 
-    // update the statistics
-    statistics.n_active = n_tracks;
-    statistics.n_lost = n_lost;
-    statistics.n_conflicts = n_conflicts;
-    statistics.n_tracks = this->size();
+  // update the statistics
+  statistics.n_active = n_tracks;
+  statistics.n_lost = n_lost;
+  statistics.n_conflicts = n_conflicts;
+  statistics.n_tracks = this->size();
 }
 
-int main(int, char**) {
-    //
-    // BayesianTracker b;
+int main(int, char **) {
+  //
+  // BayesianTracker b;
 }

--- a/btrack/src/tracklet.cc
+++ b/btrack/src/tracklet.cc
@@ -16,111 +16,112 @@
 
 #include "tracklet.h"
 
-Tracklet::Tracklet(const unsigned int new_ID, const TrackObjectPtr& new_object,
-                   const unsigned int max_lost, const MotionModel& model) {
-    // make a local copy of the default motion model
-    motion_model = model;
+Tracklet::Tracklet(const unsigned int new_ID, const TrackObjectPtr &new_object,
+                   const unsigned int max_lost, const MotionModel &model) {
+  // make a local copy of the default motion model
+  motion_model = model;
 
-    // set the current state to the position of the object
-    motion_model.setup(new_object);
+  // set the current state to the position of the object
+  motion_model.setup(new_object);
 
-    // make sure we set the remove flag to false
-    remove_flag = false;
+  // make sure we set the remove flag to false
+  remove_flag = false;
 
-    // starting a new tracklet
-    ID = new_ID;
-    append(new_object, false);
+  // starting a new tracklet
+  ID = new_ID;
+  append(new_object, false);
 }
 
-void Tracklet::append(const TrackObjectPtr& new_object, bool update) {
-    // append the new object to the end of the track
-    track.push_back(new_object);
+void Tracklet::append(const TrackObjectPtr &new_object, bool update) {
+  // append the new object to the end of the track
+  track.push_back(new_object);
 
-    // update the motion model and the prediction
-    if (update) {
-        motion_model.update(new_object);
-    }
+  // update the motion model and the prediction
+  if (update) {
+    motion_model.update(new_object);
+  }
 
-    // push back the prediction before the update
-    prediction.push_back(this->predict());
-    // store the Kalman filter output
-    kalman.push_back(this->motion_model.predict());
+  // push back the prediction before the update
+  prediction.push_back(this->predict());
+  // store the Kalman filter output
+  kalman.push_back(this->motion_model.predict());
 
-    // if this is a dummy object increment the lost counter
-    if (new_object->dummy) {
-        lost++;
-    } else {
-        lost = 0;  // reset this so that we don't accumulate without successive
-                   // dummy
-    }
+  // if this is a dummy object increment the lost counter
+  if (new_object->dummy) {
+    lost++;
+  } else {
+    lost = 0; // reset this so that we don't accumulate without successive
+              // dummy
+  }
 }
 
 // append a dummy object to the tracklet
 void Tracklet::append_dummy(bool update_position) {
-    if (lost > max_lost) {
-        // NOTE(arl): this should never happen
-        std::cout << "Lost: " << lost << " max: " << max_lost << std::endl;
-        return;
-    }
+  if (lost > max_lost) {
+    // NOTE(arl): this should never happen
+    std::cout << "Lost: " << lost << " max: " << max_lost << std::endl;
+    return;
+  }
 
-    if (DEBUG) {
-        std::cout << "Adding dummy to track: " << this->ID;
-        std::cout << " in frame: " << this->track.back()->t + 1 << std::endl;
-    }
+  if (DEBUG) {
+    std::cout << "Adding dummy to track: " << this->ID;
+    std::cout << " in frame: " << this->track.back()->t + 1 << std::endl;
+  }
 
-    // make a new dummy track object and populate with the prediction
-    TrackObject dummy;
-    dummy.ID = 0;
+  // make a new dummy track object and populate with the prediction
+  TrackObject dummy;
+  dummy.ID = 0;
 
-    // only update the position if we're using the motion model
-    if (update_position) {
-        // get the predicted new position
-        Prediction p = this->predict();
-        dummy.x = p.mu(0);
-        dummy.y = p.mu(1);
-        dummy.z = p.mu(2);
-    } else {
-        dummy.x = this->track.back()->x;
-        dummy.y = this->track.back()->y;
-        dummy.z = this->track.back()->z;
-    }
+  // only update the position if we're using the motion model
+  if (update_position) {
+    // get the predicted new position
+    Prediction p = this->predict();
+    dummy.x = p.mu(0);
+    dummy.y = p.mu(1);
+    dummy.z = p.mu(2);
+  } else {
+    dummy.x = this->track.back()->x;
+    dummy.y = this->track.back()->y;
+    dummy.z = this->track.back()->z;
+  }
 
-    dummy.t = this->track.back()->t + 1;      // NOTE(arl): valid assumption?
-    dummy.label = this->track.back()->label;  // NOTE(arl): valid assumption?
-    // dummy.label = STATE_dummy;
-    dummy.dummy = true;
-    dummy.n_features = this->track.back()->n_features;
+  dummy.t = this->track.back()->t + 1;     // NOTE(arl): valid assumption?
+  dummy.label = this->track.back()->label; // NOTE(arl): valid assumption?
+  // dummy.label = STATE_dummy;
+  dummy.dummy = true;
+  dummy.n_features = this->track.back()->n_features;
 
-    if (dummy.n_features != 0) {
-        dummy.features = this->track.back()->features;
-    }
+  if (dummy.n_features != 0) {
+    dummy.features = this->track.back()->features;
+  }
 
-    // make a shared pointer to this new obejct
-    TrackObjectPtr dummy_ptr = std::make_shared<TrackObject>(dummy);
+  // make a shared pointer to this new obejct
+  TrackObjectPtr dummy_ptr = std::make_shared<TrackObject>(dummy);
 
-    // append the dummy to the track
-    this->append(dummy_ptr);
+  // append the dummy to the track
+  this->append(dummy_ptr);
 }
 
 // Trim the tracklet to remove any dummy objects if the track has been lost
 bool Tracklet::trim() {
-    // return false if we don't need to trim
-    if (!track.back()->dummy) return false;
+  // return false if we don't need to trim
+  if (!track.back()->dummy)
+    return false;
 
-    // else iterate over and remove dummies at the end of the track
-    while (track.back()->dummy) {
-        track.pop_back();
-    }
-    return true;
+  // else iterate over and remove dummies at the end of the track
+  while (track.back()->dummy) {
+    track.pop_back();
+  }
+  return true;
 }
 
 // make a prediction about the future state of the tracklet
 // TODO(arl): make this model agnostic
 Prediction Tracklet::predict() const {
-    Prediction p_out;
-    Prediction p = motion_model.predict();
-    // p_out.mu = position() + p.mu.tail(3); // add the displacement vector
-    p_out.mu = position() + motion_model.get_motion_vector();
-    p_out.covar = p.covar.block(0, 0, 3, 3);
-    return p_out;
+  Prediction p_out;
+  Prediction p = motion_model.predict();
+  // p_out.mu = position() + p.mu.tail(3); // add the displacement vector
+  p_out.mu = position() + motion_model.get_motion_vector();
+  p_out.covar = p.covar.block(0, 0, 3, 3);
+  return p_out;
 }

--- a/btrack/src/wrapper.cc
+++ b/btrack/src/wrapper.cc
@@ -19,54 +19,54 @@
 // Interface class to coordinate the tracker, hypothesis engine and optimisation
 // Also provides a simple interface for the python facing code.
 InterfaceWrapper::InterfaceWrapper() {
-    if (DEBUG) {
-        std::cout << "Instantiating BTRACK interface wrapper (";
-        std::cout << "v" << v_major << "." << v_minor;
-        std::cout << "." << v_build << ", compiled " << build_date << " at ";
-        std::cout << build_time << ")" << std::endl;
-    }
+  if (DEBUG) {
+    std::cout << "Instantiating BTRACK interface wrapper (";
+    std::cout << "v" << v_major << "." << v_minor;
+    std::cout << "." << v_build << ", compiled " << build_date << " at ";
+    std::cout << build_time << ")" << std::endl;
+  }
 
-    // set up the track manager
-    manager = TrackManager();
+  // set up the track manager
+  manager = TrackManager();
 
-    // create a track manager instance, pass it to the tracker
-    tracker = BayesianTracker(true, UPDATE_MODE_EXACT, &manager);
+  // create a track manager instance, pass it to the tracker
+  tracker = BayesianTracker(true, UPDATE_MODE_EXACT, &manager);
 };
 
 InterfaceWrapper::~InterfaceWrapper() {
-    if (DEBUG) {
-        std::cout << "Deleting BTRACK interface wrapper" << std::endl;
-    }
+  if (DEBUG) {
+    std::cout << "Deleting BTRACK interface wrapper" << std::endl;
+  }
 };
 
 // sanity check that this is the correct verion of the shared library
 bool InterfaceWrapper::check_library_version(const uint8_t a_major,
                                              const uint8_t a_minor,
                                              const uint8_t a_build) const {
-    if (a_major == v_major && a_minor == v_minor && a_build == v_build) {
-        return true;
-    }
+  if (a_major == v_major && a_minor == v_minor && a_build == v_build) {
+    return true;
+  }
 
-    // throw an error or let python deal with it?
-    // throw std::runtime_error("Library version number mismatch.");
-    return false;
+  // throw an error or let python deal with it?
+  // throw std::runtime_error("Library version number mismatch.");
+  return false;
 }
 
 // set the tracker to store the candidate graph
 void InterfaceWrapper::set_store_candidate_graph(const bool a_store_graph) {
-    manager.set_store_candidate_graph(a_store_graph);
+  manager.set_store_candidate_graph(a_store_graph);
 }
 
 // set the update mode of the tracker
 void InterfaceWrapper::set_update_mode(const unsigned int a_update_mode) {
-    tracker.set_update_mode(a_update_mode);
+  tracker.set_update_mode(a_update_mode);
 }
 
 // set the update features of the tracker
 void InterfaceWrapper::set_update_features(
     const unsigned int a_update_features) {
-    // set the update mode for the main tracker
-    tracker.set_update_features(a_update_features);
+  // set the update mode for the main tracker
+  tracker.set_update_features(a_update_features);
 }
 
 // check the update mode of the tracker
@@ -75,266 +75,268 @@ void InterfaceWrapper::set_update_features(
 
 // tracking and basic data handling
 void InterfaceWrapper::set_motion_model(const unsigned int measurements,
-                                        const unsigned int states, double* A,
-                                        double* H, double* P, double* Q,
-                                        double* R, double dt, double accuracy,
+                                        const unsigned int states, double *A,
+                                        double *H, double *P, double *Q,
+                                        double *R, double dt, double accuracy,
                                         unsigned int max_lost,
                                         double prob_not_assign) {
-    // set the motion model of the tracker
-    tracker.set_motion_model(measurements, states, A, H, P, Q, R, dt, accuracy,
-                             max_lost, prob_not_assign);
+  // set the motion model of the tracker
+  tracker.set_motion_model(measurements, states, A, H, P, Q, R, dt, accuracy,
+                           max_lost, prob_not_assign);
 };
 
 // set the maximum search radius
 void InterfaceWrapper::set_max_search_radius(const float max_search_radius) {
-    tracker.set_max_search_radius(max_search_radius);
+  tracker.set_max_search_radius(max_search_radius);
 }
 
 // append a new object to the tracker
 void InterfaceWrapper::append(const PyTrackObject a_object) {
-    tracker.append(a_object);
+  tracker.append(a_object);
 };
 
 // run the complete tracking
-const PyTrackInfo* InterfaceWrapper::track() {
-    tracker.track_all();
-    return tracker.stats();
+const PyTrackInfo *InterfaceWrapper::track() {
+  tracker.track_all();
+  return tracker.stats();
 };
 
 // track for n steps (interactive mode)
-const PyTrackInfo* InterfaceWrapper::step(const unsigned int a_steps) {
-    tracker.step(a_steps);
-    return tracker.stats();
+const PyTrackInfo *InterfaceWrapper::step(const unsigned int a_steps) {
+  tracker.step(a_steps);
+  return tracker.stats();
 };
 
 // return the length of a track by ID
 unsigned int InterfaceWrapper::track_length(const unsigned int a_idx) const {
-    // return tracker.tracks[a_ID]->length();
-    return manager.get_track(a_idx)->length();
+  // return tracker.tracks[a_ID]->length();
+  return manager.get_track(a_idx)->length();
 };
 
 // return the internal ID of the track
 unsigned int InterfaceWrapper::get_ID(const unsigned int a_idx) const {
-    // TODO(arl): all renamed tracks should have been removed but do we need
-    // to do a sanity check?!
-    return manager.get_track(a_idx)->ID;
+  // TODO(arl): all renamed tracks should have been removed but do we need
+  // to do a sanity check?!
+  return manager.get_track(a_idx)->ID;
 }
 
 // get a track by ID
-unsigned int InterfaceWrapper::get_track(double* output,
+unsigned int InterfaceWrapper::get_track(double *output,
                                          const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    unsigned int n_frames = trk->length();
-    const unsigned int N = 3 + 1;
+  unsigned int n_frames = trk->length();
+  const unsigned int N = 3 + 1;
 
-    // NOTE: Grab the actual track
-    for (unsigned int i = 0; i < n_frames; i++) {
-        // frame number
-        output[i * N + 0] = trk->track[i]->t;
-        output[i * N + 1] = trk->track[i]->x;
-        output[i * N + 2] = trk->track[i]->y;
-        output[i * N + 3] = trk->track[i]->z;
-        // output[i*N+4] = tracker.tracks[a_idx]->track[i]->dummy;
-    }
+  // NOTE: Grab the actual track
+  for (unsigned int i = 0; i < n_frames; i++) {
+    // frame number
+    output[i * N + 0] = trk->track[i]->t;
+    output[i * N + 1] = trk->track[i]->x;
+    output[i * N + 2] = trk->track[i]->y;
+    output[i * N + 3] = trk->track[i]->z;
+    // output[i*N+4] = tracker.tracks[a_idx]->track[i]->dummy;
+  }
 
-    return n_frames;
+  return n_frames;
 };
 
 // return the references to the objects
-unsigned int InterfaceWrapper::get_refs(int* output,
+unsigned int InterfaceWrapper::get_refs(int *output,
                                         const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    unsigned int n_frames = trk->length();
+  unsigned int n_frames = trk->length();
 
-    for (unsigned int i = 0; i < n_frames; i++) {
-        output[i] = trk->track[i]->ID;
-    }
-    return n_frames;
+  for (unsigned int i = 0; i < n_frames; i++) {
+    output[i] = trk->track[i]->ID;
+  }
+  return n_frames;
 };
 
 // return the ID of the parent
 unsigned int InterfaceWrapper::get_parent(const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    return trk->parent;
+  return trk->parent;
 }
 
 // return the ID of the root
 unsigned int InterfaceWrapper::get_root(const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    return trk->root;
+  return trk->root;
 }
 
 // return the ID of the children
-unsigned int InterfaceWrapper::get_children(int* children,
+unsigned int InterfaceWrapper::get_children(int *children,
                                             const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    // if the track has no children, return zero
-    if (!trk->has_children()) {
-        return 0;
-    }
+  // if the track has no children, return zero
+  if (!trk->has_children()) {
+    return 0;
+  }
 
-    // otherwise return the IDs of the children
-    children[0] = trk->child_one;
-    children[1] = trk->child_two;
-    return 2;
+  // otherwise return the IDs of the children
+  children[0] = trk->child_one;
+  children[1] = trk->child_two;
+  return 2;
 }
 
 // return the fate (as assigned by the optimizer)
 unsigned int InterfaceWrapper::get_fate(const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    return trk->fate;
+  return trk->fate;
 }
 
 // get the generational depth of the track
 unsigned int InterfaceWrapper::get_generation(const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    return trk->generation;
+  return trk->generation;
 }
 
-unsigned int InterfaceWrapper::get_kalman_mu(double* output,
+unsigned int InterfaceWrapper::get_kalman_mu(double *output,
                                              const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    // NOTE: This is grabbing the Kalman filter rather than the track!
-    const unsigned int N = 3 + 1;
-    unsigned int n_frames = trk->length();
-    for (unsigned int i = 0; i < n_frames; i++) {
-        output[i * N + 0] = trk->track[i]->t;
-        output[i * N + 1] = trk->kalman[i].mu(0);
-        output[i * N + 2] = trk->kalman[i].mu(1);
-        output[i * N + 3] = trk->kalman[i].mu(2);
-    }
-    return n_frames;
+  // NOTE: This is grabbing the Kalman filter rather than the track!
+  const unsigned int N = 3 + 1;
+  unsigned int n_frames = trk->length();
+  for (unsigned int i = 0; i < n_frames; i++) {
+    output[i * N + 0] = trk->track[i]->t;
+    output[i * N + 1] = trk->kalman[i].mu(0);
+    output[i * N + 2] = trk->kalman[i].mu(1);
+    output[i * N + 3] = trk->kalman[i].mu(2);
+  }
+  return n_frames;
 };
 
-unsigned int InterfaceWrapper::get_kalman_covar(
-    double* output, const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+unsigned int
+InterfaceWrapper::get_kalman_covar(double *output,
+                                   const unsigned int a_idx) const {
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    // NOTE: This is grabbing the Kalman filter rather than the track!
-    const unsigned int N = 9 + 1;
-    unsigned int n_frames = trk->length();
-    for (unsigned int i = 0; i < n_frames; i++) {
-        output[i * N + 0] = trk->track[i]->t;
-        output[i * N + 1] = trk->kalman[i].covar(0, 0);
-        output[i * N + 2] = trk->kalman[i].covar(0, 1);
-        output[i * N + 3] = trk->kalman[i].covar(0, 2);
-        output[i * N + 4] = trk->kalman[i].covar(1, 0);
-        output[i * N + 5] = trk->kalman[i].covar(1, 1);
-        output[i * N + 6] = trk->kalman[i].covar(1, 2);
-        output[i * N + 7] = trk->kalman[i].covar(2, 0);
-        output[i * N + 8] = trk->kalman[i].covar(2, 1);
-        output[i * N + 9] = trk->kalman[i].covar(2, 2);
-    }
-    return n_frames;
+  // NOTE: This is grabbing the Kalman filter rather than the track!
+  const unsigned int N = 9 + 1;
+  unsigned int n_frames = trk->length();
+  for (unsigned int i = 0; i < n_frames; i++) {
+    output[i * N + 0] = trk->track[i]->t;
+    output[i * N + 1] = trk->kalman[i].covar(0, 0);
+    output[i * N + 2] = trk->kalman[i].covar(0, 1);
+    output[i * N + 3] = trk->kalman[i].covar(0, 2);
+    output[i * N + 4] = trk->kalman[i].covar(1, 0);
+    output[i * N + 5] = trk->kalman[i].covar(1, 1);
+    output[i * N + 6] = trk->kalman[i].covar(1, 2);
+    output[i * N + 7] = trk->kalman[i].covar(2, 0);
+    output[i * N + 8] = trk->kalman[i].covar(2, 1);
+    output[i * N + 9] = trk->kalman[i].covar(2, 2);
+  }
+  return n_frames;
 };
 
-unsigned int InterfaceWrapper::get_kalman_pred(double* output,
+unsigned int InterfaceWrapper::get_kalman_pred(double *output,
                                                const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    // NOTE: This is grabbing the Kalman filter rather than the track!
-    const unsigned int N = 3 + 1;
-    unsigned int n_frames = trk->length();
-    for (unsigned int i = 0; i < n_frames; i++) {
-        output[i * N + 0] = trk->track[i]->t;
-        output[i * N + 1] = trk->prediction[i].mu(0);
-        output[i * N + 2] = trk->prediction[i].mu(1);
-        output[i * N + 3] = trk->prediction[i].mu(2);
-    }
-    return n_frames;
+  // NOTE: This is grabbing the Kalman filter rather than the track!
+  const unsigned int N = 3 + 1;
+  unsigned int n_frames = trk->length();
+  for (unsigned int i = 0; i < n_frames; i++) {
+    output[i * N + 0] = trk->track[i]->t;
+    output[i * N + 1] = trk->prediction[i].mu(0);
+    output[i * N + 2] = trk->prediction[i].mu(1);
+    output[i * N + 3] = trk->prediction[i].mu(2);
+  }
+  return n_frames;
 };
 
-unsigned int InterfaceWrapper::get_label(unsigned int* output,
+unsigned int InterfaceWrapper::get_label(unsigned int *output,
                                          const unsigned int a_idx) const {
-    TrackletPtr trk = manager.get_track(a_idx);
+  TrackletPtr trk = manager.get_track(a_idx);
 
-    // NOTE: This is grabbing the labels from the track!
-    const unsigned int N = 1 + 1;
-    unsigned int n_frames = trk->length();
-    for (unsigned int i = 0; i < n_frames; i++) {
-        output[i * N + 0] = trk->track[i]->t;
-        output[i * N + 1] = trk->track[i]->label;
-    }
-    return n_frames;
+  // NOTE: This is grabbing the labels from the track!
+  const unsigned int N = 1 + 1;
+  unsigned int n_frames = trk->length();
+  for (unsigned int i = 0; i < n_frames; i++) {
+    output[i * N + 0] = trk->track[i]->t;
+    output[i * N + 1] = trk->track[i]->label;
+  }
+  return n_frames;
 };
 
 // return the imaging volume
-void InterfaceWrapper::get_volume(double* a_volume) const {
-    a_volume[0] = tracker.volume.min_xyz(0);
-    a_volume[1] = tracker.volume.max_xyz(0);
-    a_volume[2] = tracker.volume.min_xyz(1);
-    a_volume[3] = tracker.volume.max_xyz(1);
-    a_volume[4] = tracker.volume.min_xyz(2);
-    a_volume[5] = tracker.volume.max_xyz(2);
+void InterfaceWrapper::get_volume(double *a_volume) const {
+  a_volume[0] = tracker.volume.min_xyz(0);
+  a_volume[1] = tracker.volume.max_xyz(0);
+  a_volume[2] = tracker.volume.min_xyz(1);
+  a_volume[3] = tracker.volume.max_xyz(1);
+  a_volume[4] = tracker.volume.min_xyz(2);
+  a_volume[5] = tracker.volume.max_xyz(2);
 };
 
 // set the imaging volume
-void InterfaceWrapper::set_volume(const double* a_volume) {
-    tracker.volume.set_volume(a_volume);
+void InterfaceWrapper::set_volume(const double *a_volume) {
+  tracker.volume.set_volume(a_volume);
 }
 
 PyTrackObject InterfaceWrapper::get_dummy(const int a_idx) {
-    // get a pointer to the track manager
-    // p_manager = &tracker.tracks;
-    return manager.get_dummy(a_idx)->get_pytrack_object();
+  // get a pointer to the track manager
+  // p_manager = &tracker.tracks;
+  return manager.get_dummy(a_idx)->get_pytrack_object();
 }
 
 PyGraphEdge InterfaceWrapper::get_graph_edge(const size_t a_idx) {
-    // p_manager = &tracker.tracks;
-    return manager.get_edge(a_idx);
+  // p_manager = &tracker.tracks;
+  return manager.get_edge(a_idx);
 }
 
 // hypothesis generation
-unsigned int InterfaceWrapper::create_hypotheses(
-    const PyHypothesisParams a_params, const unsigned int a_start_n,
-    const unsigned int a_end_n) {
-    // set up a new hypothesis engine with the parameters supplied
-    h_engine = HypothesisEngine(a_start_n, a_end_n, a_params, &manager);
-    h_engine.volume = tracker.volume;
+unsigned int
+InterfaceWrapper::create_hypotheses(const PyHypothesisParams a_params,
+                                    const unsigned int a_start_n,
+                                    const unsigned int a_end_n) {
+  // set up a new hypothesis engine with the parameters supplied
+  h_engine = HypothesisEngine(a_start_n, a_end_n, a_params, &manager);
+  h_engine.volume = tracker.volume;
 
-    // set the hypothesis engine update features to match the tracker
-    h_engine.set_update_features(tracker.get_update_features());
+  // set the hypothesis engine update features to match the tracker
+  h_engine.set_update_features(tracker.get_update_features());
 
-    // add all of the tracks to the engine
-    for (size_t i = 0; i < manager.num_tracks(); i++) {
-        h_engine.add_track(manager.get_track(i));
-    }
+  // add all of the tracks to the engine
+  for (size_t i = 0; i < manager.num_tracks(); i++) {
+    h_engine.add_track(manager.get_track(i));
+  }
 
-    // create the hypotheses
-    h_engine.create();
+  // create the hypotheses
+  h_engine.create();
 
-    return h_engine.size();
+  return h_engine.size();
 };
 
 // get a hypothesis by ID
 PyHypothesis InterfaceWrapper::get_hypothesis(const unsigned int a_idx) {
-    return h_engine.get_hypothesis(a_idx);
+  return h_engine.get_hypothesis(a_idx);
 };
 
 // merge tracks based on hypothesis IDs
-void InterfaceWrapper::merge(unsigned int* a_hypotheses,
+void InterfaceWrapper::merge(unsigned int *a_hypotheses,
                              unsigned int n_hypotheses) {
-    // make a vector of hypotheses to merge
-    std::vector<Hypothesis> merges;
-    merges.reserve(n_hypotheses);
+  // make a vector of hypotheses to merge
+  std::vector<Hypothesis> merges;
+  merges.reserve(n_hypotheses);
 
-    // get a pointer to the track manager
-    // p_manager = &tracker.tracks;
+  // get a pointer to the track manager
+  // p_manager = &tracker.tracks;
 
-    // add all of the hypotheses
-    for (size_t i = 0; i < n_hypotheses; i++) {
-        unsigned int idx = a_hypotheses[i];
-        merges.push_back(h_engine.m_hypotheses[idx]);
-    }
+  // add all of the hypotheses
+  for (size_t i = 0; i < n_hypotheses; i++) {
+    unsigned int idx = a_hypotheses[i];
+    merges.push_back(h_engine.m_hypotheses[idx]);
+  }
 
-    // now run the merging
-    manager.merge(merges);
+  // now run the merging
+  manager.merge(merges);
 }

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -293,7 +293,3 @@ def update_segmentation(
         )
 
     return relabeled
-
-
-if __name__ == "__main__":
-    pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,7 +72,6 @@ def test_config_tracker_setters():
     """Test configuring the tracker using setters."""
     options = _random_config()
     with btrack.BayesianTracker() as tracker:
-
         # use the setters to apply the comfiguration
         for key, value in options.items():
             setattr(tracker, key, value)


### PR DESCRIPTION
Fixes #241. I found that https://github.com/pre-commit/mirrors-clang-format worked out of the box without dependencies, unlike https://github.com/pocc/pre-commit-hooks. This means we're using `clang` style rather than `Google`. A lot of formatting changes, but this means it will just automatically apply in future.