### PR TITLE
Add debug info logger

### DIFF
--- a/btrack/constants.py
+++ b/btrack/constants.py
@@ -1,8 +1,7 @@
 import enum
-import os
 from pathlib import Path
 
-BTRACK_PATH = os.path.dirname(os.path.abspath(__file__))
+BTRACK_PATH = Path(__file__).resolve().parent
 BTRACK_LIB_PATH = Path(BTRACK_PATH) / "libs" / "libtracker"
 
 MAX_SEARCH_RADIUS = 100

--- a/btrack/constants.py
+++ b/btrack/constants.py
@@ -1,7 +1,9 @@
 import enum
 import os
+from pathlib import Path
 
 BTRACK_PATH = os.path.dirname(os.path.abspath(__file__))
+BTRACK_LIB_PATH = Path(BTRACK_PATH) / "libs" / "libtracker"
 
 MAX_SEARCH_RADIUS = 100
 DEFAULT_LOW_PROBABILITY = -1e5

--- a/btrack/libwrapper.py
+++ b/btrack/libwrapper.py
@@ -77,7 +77,7 @@ def load_library(filename: os.PathLike) -> ctypes.CDLL:
     system = platform.system()
 
     file_ext = {"Linux": ".so", "Darwin": ".dylib", "Windows": ".DLL"}
-    full_lib_file = lib_file.with_suffix(file_ext[system])
+    full_lib_file = str(lib_file.with_suffix(file_ext[system]))
 
     lib = ctypes.cdll.LoadLibrary(full_lib_file)
     logger.info(f"Loaded btrack: {full_lib_file}")

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 from typing import List, Optional
 
@@ -293,3 +294,31 @@ def update_segmentation(
         )
 
     return relabeled
+
+
+def log_debug_info(fn):
+    """Wrapper to provide additional debug info when loading a shared library
+    or any other function that needs special debuggin info."""
+
+    @functools.wraps(fn)
+    def wrapped_func_to_debug(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as err:
+            from platform import platform
+
+            from ._version import version
+
+            logger.error(
+                "DEBUG INFO: \n"
+                f" - btrack: v{version} \n"
+                f" - Platform: {platform()} \n"
+                f" - Function: {fn} \n"
+                f" - Exception: {err} \n"
+                f" - Arguments: {args} \n"
+                f" - Kwargs: {kwargs} \n"
+            )
+
+            raise Exception from err
+
+    return wrapped_func_to_debug


### PR DESCRIPTION
Adds a decorator that can be used to capture debug info like the user platform and btrack version. Could be useful for user generated issues/bug reports?