### PR TITLE
Fix mac silicon for napari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+_version.py
 .cache
 .coverage
 .coverage.*
@@ -63,5 +64,5 @@ pip-delete-this-directory.txt
 pip-log.txt
 sdist
 target
+user_config.json
 var
-_version.py

--- a/.napari-hub/DESCRIPTION.md
+++ b/.napari-hub/DESCRIPTION.md
@@ -31,3 +31,18 @@ We developed `btrack` for cell tracking in time-lapse microscopy data.
 ## associated plugins
 
 * [napari-arboretum](https://www.napari-hub.org/plugins/napari-arboretum) - Napari plugin to enable track graph and lineage tree visualization.
+
+## Installation
+
+To install the `napari` plugin associated with `btrack` run the command.
+
+```sh
+pip install btrack[napari]
+```
+
+If working on M1 Mac/Apple Silicon/osx-arm64 make sure to install the following
+packages from `conda-forge`.
+
+```sh
+conda install -c conda-forge cvxopt pyqt
+```

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - cvxopt>=1.2.0
-  - h5py>=2.10.0
+  - pyqt>=5.15.7
   - pip
   - python=3.10
   - pip:


### PR DESCRIPTION
I've been struggling to develop the whole time and realised stuff is on `conda` now which wasn't before, so have worked it out and written it down. `h5py` seems to now be universal on PyPI, so no longer needed in the `environment.yaml`.

Related #217. Still think it would better to remove the `environment.yaml` file in favour of documenting the fact that you just need to install those packages from `PyPI`. For example, for this to work I've had to add `pyqt` to `environment.yaml`, whereas in `pyproject.toml` we are making `pyqt` only required when doing `pip install btrack[napari]`.