### PR TITLE
Add issue templates and `SystemInformation` class

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Report issues installing or running btrack
+title: "[BUG]"
+labels: bug
+assignees: ""
+
+---
+
+**Describe the bug**
+Please describe the bug, including any error messages. Provide screenshots if available.
+
+**Your setup:**
+Please use `btrack.SystemInformation()` to report the details of your system.
+
+**Comments**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Request a feature
+title: "[FEATURE REQUEST]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Please describe the `btrack` feature you'd like to add**

--- a/btrack/__init__.py
+++ b/btrack/__init__.py
@@ -1,7 +1,8 @@
 import logging
 
-from ._version import version
-from .core import BayesianTracker, SystemInformation
+from btrack._version import version
+from btrack.core import BayesianTracker
+from btrack.utils import SystemInformation
 
 __all__ = ["BayesianTracker"]
 __version__ = version

--- a/btrack/__init__.py
+++ b/btrack/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from ._version import version
-from .core import BayesianTracker
+from .core import BayesianTracker, SystemInformation
 
 __all__ = ["BayesianTracker"]
 __version__ = version

--- a/btrack/constants.py
+++ b/btrack/constants.py
@@ -1,8 +1,12 @@
 import enum
+import platform
 from pathlib import Path
 
 BTRACK_PATH = Path(__file__).resolve().parent
 BTRACK_LIB_PATH = Path(BTRACK_PATH) / "libs" / "libtracker"
+
+BTRACK_PLATFORM = platform.platform()
+BTRACK_PYTHON_VERSION = platform.python_version()
 
 MAX_SEARCH_RADIUS = 100
 DEFAULT_LOW_PROBABILITY = -1e5

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -19,17 +19,6 @@ __version__ = _version.version
 logger = logging.getLogger(__name__)
 
 
-class SystemInformation:
-    from btrack.utils import _debug_info
-
-    _info = _debug_info()
-
-    def __repr__(self) -> str:
-        return "\n".join(
-            [f"{key}: {value}" for key, value in self._info.items()]
-        )
-
-
 class BayesianTracker:
     """BayesianTracker.
 

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -19,6 +19,17 @@ __version__ = _version.version
 logger = logging.getLogger(__name__)
 
 
+class SystemInformation:
+    from btrack.utils import _debug_info
+
+    _info = _debug_info()
+
+    def __repr__(self) -> str:
+        return "\n".join(
+            [f"{key}: {value}" for key, value in self._info.items()]
+        )
+
+
 class BayesianTracker:
     """BayesianTracker.
 

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+import dataclasses
 import functools
 import logging
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 import numpy as np
 from skimage.util import map_array
 
 # import core
-from . import btypes, constants
+from . import _version, btypes, constants
 from .constants import DEFAULT_EXPORT_PROPERTIES, Dimensionality
 from .io._localization import segmentation_to_objects
 from .models import HypothesisModel, MotionModel, ObjectModel
@@ -296,16 +297,20 @@ def update_segmentation(
     return relabeled
 
 
-def _debug_info() -> Dict[str, Any]:
-    import platform
+@dataclasses.dataclass(frozen=True, init=False)
+class SystemInformation:
+    btrack_version: str = _version.version
+    system_platform: str = constants.BTRACK_PLATFORM
+    system_python: str = constants.BTRACK_PYTHON_VERSION
 
-    from ._version import version
-
-    return {
-        "version": version,
-        "platform": platform.platform(),
-        "python": platform.python_version(),
-    }
+    def __repr__(self) -> str:
+        # override to have slightly nicer formatting
+        return "\n".join(
+            [
+                f"{key}: {value}"
+                for key, value in dataclasses.asdict(self).items()
+            ]
+        )
 
 
 def log_debug_info(fn):
@@ -317,7 +322,7 @@ def log_debug_info(fn):
         try:
             return fn(*args, **kwargs)
         except Exception as err:
-            debug_info = _debug_info()
+            debug_info = dataclasses.asdict(SystemInformation())
             exception_info = {
                 "function": fn,
                 "exception": err,

--- a/tests/test_shared_lib.py
+++ b/tests/test_shared_lib.py
@@ -1,0 +1,30 @@
+import platform
+from pathlib import Path
+
+import pytest
+
+import btrack
+from btrack.constants import BTRACK_LIB_PATH
+from btrack.libwrapper import load_library
+
+
+def test_load_library():
+    """Test loading the shared library."""
+    load_library(BTRACK_LIB_PATH)
+
+
+def test_fails_load_library_debug(tmp_path):
+    """Test loading a fake shared library."""
+    fake_lib_filename = Path(tmp_path) / "fakelib"
+    with pytest.raises(Exception):
+        load_library(fake_lib_filename)
+
+
+def test_debug_info():
+    """Test debugging info."""
+    system_info = btrack.SystemInformation()
+
+    assert isinstance(repr(system_info), str)
+    assert system_info._info["version"] == btrack.__version__
+    assert system_info._info["platform"] == platform.platform()
+    assert system_info._info["python"] == platform.python_version()

--- a/tests/test_shared_lib.py
+++ b/tests/test_shared_lib.py
@@ -25,6 +25,6 @@ def test_debug_info():
     system_info = btrack.SystemInformation()
 
     assert isinstance(repr(system_info), str)
-    assert system_info._info["version"] == btrack.__version__
-    assert system_info._info["platform"] == platform.platform()
-    assert system_info._info["python"] == platform.python_version()
+    assert system_info.btrack_version == btrack.__version__
+    assert system_info.system_platform == platform.platform()
+    assert system_info.system_python == platform.python_version()


### PR DESCRIPTION
* Adds issue templates
* Provides a `SystemInformation` class to enable users to easily report their system and `btrack` version
* Few small typo fixes
* Add missing tests from original PR

<img width="692" alt="Screenshot 2023-04-26 at 10 25 32" src="https://user-images.githubusercontent.com/8217795/234541882-2dbd999e-c221-4c3f-b240-7f821ba89017.png">


Closes #191