### PR TITLE
Handle 4D data in the napari plugin

### DIFF
--- a/btrack/napari/main.py
+++ b/btrack/napari/main.py
@@ -170,7 +170,7 @@ def _run_tracker(
         tracker.optimize()
 
         # get the tracks in a format for napari visualization
-        data, properties, graph = tracker.to_napari(ndim=2)
+        data, properties, graph = tracker.to_napari()
         return data, properties, graph
 
 


### PR DESCRIPTION
Fixes #316 

Changes made:
- don't specify `ndim` when converting tracks to a napari layer - let `BayesianTracker` determine the dimensionality