### PR TITLE
Fix plugin name in example script

### DIFF
--- a/btrack/napari/examples/show_btrack_widget.py
+++ b/btrack/napari/examples/show_btrack_widget.py
@@ -15,7 +15,7 @@ viewer = napari.Viewer()
 napari.current_viewer()
 
 _, btrack_widget = viewer.window.add_plugin_dock_widget(
-    plugin_name="napari-btrack", widget_name="Track"
+    plugin_name="btrack", widget_name="Track"
 )
 
 


### PR DESCRIPTION
Plugin name in the example script is incorrect since merging the repos.