### PR TITLE
Add legacy h5 support and tree inspection

### DIFF
--- a/btrack/io/hdf.py
+++ b/btrack/io/hdf.py
@@ -263,11 +263,24 @@ class HDF5FileHandler:
 
             f_eval = f"x{m['op']}{m['cmp']}"  # e.g. x > 10
 
+            data = None
+
             if m["name"] in properties:
                 data = properties[m["name"]]
-                filtered_idx = [i for i, x in enumerate(data) if eval(f_eval)]
+            elif m["name"] in grp:
+                logger.warning(
+                    f"While trying to filter objects by `{f_expr}` encountered "
+                    "a legacy HDF file."
+                )
+                logger.warning(
+                    "Properties do not persist to objects. Use `hdf.tree()` to "
+                    "inspect the file structure."
+                )
+                data = grp[m["name"]]
             else:
                 raise ValueError(f"Cannot filter objects by {f_expr}")
+
+            filtered_idx = [i for i, x in enumerate(data) if eval(f_eval)]
 
         else:
             filtered_idx = range(txyz.shape[0])  # default filtering uses all
@@ -594,3 +607,41 @@ class HDF5FileHandler:
         """Return the LBEP data."""
         logger.info(f"Loading LBEP/{self.object_type}")
         return self._hdf["tracks"][self.object_type]["LBEPR"][:]
+
+    def tree(self) -> None:
+        """Recursively iterate over the H5 file to reveal the tree structure and number
+        of elements within."""
+        _h5_tree(self._hdf)
+
+
+def _h5_tree(hdf, *, pre: str = "") -> None:
+    """Recursively iterate over an H5 file to reveal the tree structure and number
+    of elements within. Writes the output to the default logger.
+
+    Parameters
+    ----------
+    hdf : hdf object
+        The hdf object to iterate over
+    pre : str
+        A prepended string for layout
+
+    Returns
+    -------
+    None
+    """
+    n_items = len(hdf)
+    for idx, (key, val) in enumerate(hdf.items()):
+        # items -= 1
+        # if items == 0:
+        if idx == (n_items - 1):
+            # the last item
+            if isinstance(val, h5py._hl.group.Group):
+                logger.info(f"{pre}└── {key}")
+                _h5_tree(val, pre=f"{pre}    ")
+            else:
+                logger.info(f"{pre}└── {key} ({len(val)})")
+        elif isinstance(val, h5py._hl.group.Group):
+            logger.info(f"{pre}├── {key}")
+            _h5_tree(val, pre=f"{pre}│   ")
+        else:
+            logger.info(f"{pre}├── {key} ({len(val)})")

--- a/btrack/io/hdf.py
+++ b/btrack/io/hdf.py
@@ -280,7 +280,7 @@ class HDF5FileHandler:
             else:
                 raise ValueError(f"Cannot filter objects by {f_expr}")
 
-            filtered_idx = [i for i, x in enumerate(data) if eval(f_eval)]
+            filtered_idx = [i for i, _ in enumerate(data) if eval(f_eval)]
 
         else:
             filtered_idx = range(txyz.shape[0])  # default filtering uses all
@@ -614,7 +614,7 @@ class HDF5FileHandler:
         _h5_tree(self._hdf)
 
 
-def _h5_tree(hdf, *, pre: str = "") -> None:
+def _h5_tree(hdf, *, prefix: str = "") -> None:
     """Recursively iterate over an H5 file to reveal the tree structure and number
     of elements within. Writes the output to the default logger.
 
@@ -622,26 +622,20 @@ def _h5_tree(hdf, *, pre: str = "") -> None:
     ----------
     hdf : hdf object
         The hdf object to iterate over
-    pre : str
+    prefix : str
         A prepended string for layout
-
-    Returns
-    -------
-    None
     """
     n_items = len(hdf)
     for idx, (key, val) in enumerate(hdf.items()):
-        # items -= 1
-        # if items == 0:
         if idx == (n_items - 1):
             # the last item
             if isinstance(val, h5py._hl.group.Group):
-                logger.info(f"{pre}└── {key}")
-                _h5_tree(val, pre=f"{pre}    ")
+                logger.info(f"{prefix}└── {key}")
+                _h5_tree(val, prefix=f"{prefix}    ")
             else:
-                logger.info(f"{pre}└── {key} ({len(val)})")
+                logger.info(f"{prefix}└── {key} ({len(val)})")
         elif isinstance(val, h5py._hl.group.Group):
-            logger.info(f"{pre}├── {key}")
-            _h5_tree(val, pre=f"{pre}│   ")
+            logger.info(f"{prefix}├── {key}")
+            _h5_tree(val, prefix=f"{prefix}│   ")
         else:
-            logger.info(f"{pre}├── {key} ({len(val)})")
+            logger.info(f"{prefix}├── {key} ({len(val)})")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -167,3 +167,20 @@ def test_write_hdf_segmentation(hdf5_file_path):
     with btrack.io.HDF5FileHandler(hdf5_file_path, "r") as h:
         segmentation_from_file = h.segmentation
     np.testing.assert_equal(segmentation, segmentation_from_file)
+
+
+def test_hdf_tree(hdf5_file_path, caplog):
+    """Test that the tree function iterates over the files and writes the output
+    to the logger."""
+    n_log_entries = len(caplog.records)
+
+    # first test with an empty tree
+    btrack.io.hdf._h5_tree({})
+
+    assert len(caplog.records) == n_log_entries
+
+    with btrack.io.HDF5FileHandler(hdf5_file_path, "r") as hdf:
+        hdf.tree()
+
+    n_expected_entries = 8
+    assert len(caplog.records) == n_log_entries + n_expected_entries


### PR DESCRIPTION
Fix for @Jasminemichalowska:

+ Adds legacy support for h5 files where object properties are not stored in the `properties` subgroup
+ Adds a warning in such cases, if filtering has been applied
+ Adds a `hdf.tree()` function to help inspect file contents
+ Rudimentary test to make sure that the tree functions output something to the logger

<img width="1053" alt="Screenshot 2023-06-09 at 11 14 00" src="https://github.com/quantumjot/btrack/assets/8217795/9c36b51d-57eb-45f1-8260-856db76d7318">
