### PR TITLE
Expose `prob_not_assign` in the plugin

### DIFF
--- a/btrack/napari/sync.py
+++ b/btrack/napari/sync.py
@@ -35,6 +35,7 @@ def update_config_from_widgets(
     motion_model = config.motion_model
     motion_model.accuracy = btrack_widget.accuracy.value()
     motion_model.max_lost = btrack_widget.max_lost.value()
+    motion_model.prob_not_assign = btrack_widget.prob_not_assign.value()
 
     # Update HypothesisModel.hypotheses values
     hypothesis_model = config.hypothesis_model
@@ -86,6 +87,7 @@ def update_widgets_from_config(
     motion_model = config.motion_model
     btrack_widget.accuracy.setValue(motion_model.accuracy)
     btrack_widget.max_lost.setValue(motion_model.max_lost)
+    btrack_widget.prob_not_assign.setValue(motion_model.prob_not_assign)
 
     # Update widgets from HypothesisModel.hypotheses values
     hypothesis_model = config.hypothesis_model

--- a/btrack/napari/widgets/_motion.py
+++ b/btrack/napari/widgets/_motion.py
@@ -66,7 +66,8 @@ def create_motion_model_widgets() -> dict[str, tuple(str, QtWidgets.QWidget)]:
 
     not_assign = QtWidgets.QDoubleSpinBox()
     not_assign.setToolTip("Default probability to not assign a track")
-    not_assign.setValue(0.1)
+    not_assign.setDecimals(3)
+    not_assign.setValue(0.001)
     not_assign.setRange(0, 1)
     not_assign.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     widgets["prob_not_assign"] = (

--- a/btrack/napari/widgets/_motion.py
+++ b/btrack/napari/widgets/_motion.py
@@ -64,4 +64,14 @@ def create_motion_model_widgets() -> dict[str, tuple(str, QtWidgets.QWidget)]:
     )
     widgets["max_lost"] = ("max lost", max_lost_frames)
 
+    not_assign = QtWidgets.QDoubleSpinBox()
+    not_assign.setToolTip("Default probability to not assign a track")
+    not_assign.setValue(0.1)
+    not_assign.setRange(0, 1)
+    not_assign.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
+    widgets["prob_not_assign"] = (
+        f"{_make_label_bold('P')}(not track)",
+        not_assign,
+    )
+
     return widgets


### PR DESCRIPTION
Fixes #289 

- Added to the `Motion` tab
- Uses a `QDoubleSpinBox` with a default value of 0.001, as this is the value used by the [cell](https://raw.githubusercontent.com/lowe-lab-ucl/btrack-examples/main/examples/cell_config.json) and [particle](https://raw.githubusercontent.com/lowe-lab-ucl/btrack-examples/main/examples/particle_config.json) example configs (which we load into the plugin at launch)
- Used a label `P(not track)` with tooltip 'Default probability to not assign a track' - are these suitable?

<img width="326" alt="prob_not_assign" src="https://github.com/quantumjot/btrack/assets/29753790/b7224989-ba20-4a72-89c8-adce5e0e9e65">

