### PR TITLE
Remove excess spacing between the tab widget and the Run button

### DIFF
--- a/btrack/napari/widgets/create_ui.py
+++ b/btrack/napari/widgets/create_ui.py
@@ -58,12 +58,17 @@ class BtrackWidget(QtWidgets.QScrollArea):
         self._widgets = {}
         self._add_input_widgets()
         # This must be added after the input widgets
-        self._main_layout.addWidget(self._tabs)
+        self._main_layout.addWidget(self._tabs, stretch=0)
         self._add_update_method_widgets()
         self._add_motion_model_widgets()
         self._add_hypothesis_model_widgets()
         self._add_io_widgets()
         self._add_track_widgets()
+
+        # Expand the main widget
+        self._main_layout.addStretch(stretch=1)
+
+        # Add attribute access for each widget
         for name, widget in self._widgets.items():
             self.__setattr__(
                 name,
@@ -82,7 +87,7 @@ class BtrackWidget(QtWidgets.QScrollArea):
         for label, widget in labels_and_widgets.values():
             layout.addRow(QtWidgets.QLabel(label), widget)
         widget_holder.setLayout(layout)
-        self._main_layout.addWidget(widget_holder)
+        self._main_layout.addWidget(widget_holder, stretch=0)
 
     def _add_update_method_widgets(self) -> None:
         """Create update method widgets and add to main layout"""
@@ -147,4 +152,4 @@ class BtrackWidget(QtWidgets.QScrollArea):
         track_widgets = create_track_widgets()
         self._widgets.update(track_widgets)
         for widget in track_widgets.values():
-            self._main_layout.addWidget(widget)
+            self._main_layout.addWidget(widget, stretch=0)


### PR DESCRIPTION
Part of #266 

- remove large space between the tab widget and the Run button

previously:
<img width="328" alt="with-spacing" src="https://github.com/quantumjot/btrack/assets/29753790/834b12b3-2906-4c6a-b9e7-966197ee07c8">


now:
<img width="328" alt="spacing-removed" src="https://github.com/quantumjot/btrack/assets/29753790/56227a9f-aee1-4125-bf0c-323a548b1308">

