### PR TITLE
Add default ranges for numerical issues

### DIFF
--- a/btrack/napari/widgets/_general.py
+++ b/btrack/napari/widgets/_general.py
@@ -79,32 +79,32 @@ def create_update_method_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
 
     max_search_radius = QtWidgets.QDoubleSpinBox()
     max_search_radius.setRange(0, 1000)
+    max_search_radius.setStepType(
+        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+    )
     max_search_radius.setToolTip(
         "The local spatial search radius (isotropic, pixels) used when the update "
         "method is 'APPROXIMATE'"
     )
     max_search_radius.setWrapping(True)  # noqa: FBT003
-    max_search_radius.setStepType(
-        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-    )
     widgets["max_search_radius"] = ("search radius", max_search_radius)
 
     max_lost_frames = QtWidgets.QSpinBox()
+    max_lost_frames.setStepType(
+        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+    )
     max_lost_frames.setToolTip(
         "Number of frames without observation before marking as lost"
     )
     max_lost_frames.setValue(5)
-    max_lost_frames.setStepType(
-        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-    )
     widgets["max_lost"] = ("max lost", max_lost_frames)
 
     not_assign = QtWidgets.QDoubleSpinBox()
-    not_assign.setToolTip("Default probability to not assign a track")
     not_assign.setDecimals(3)
-    not_assign.setValue(0.001)
     not_assign.setRange(0, 1)
     not_assign.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
+    not_assign.setToolTip("Default probability to not assign a track")
+    not_assign.setValue(0.001)
     widgets["prob_not_assign"] = (
         "<b>P</b>(not track)",
         not_assign,

--- a/btrack/napari/widgets/_general.py
+++ b/btrack/napari/widgets/_general.py
@@ -90,6 +90,7 @@ def create_update_method_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     widgets["max_search_radius"] = ("search radius", max_search_radius)
 
     max_lost_frames = QtWidgets.QSpinBox()
+    max_lost_frames.setRange(0, 10)
     max_lost_frames.setStepType(
         QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
     )

--- a/btrack/napari/widgets/_hypothesis.py
+++ b/btrack/napari/widgets/_hypothesis.py
@@ -72,9 +72,9 @@ def _create_scaling_factor_widgets() -> (
         widget_values, names, labels, tooltips
     ):
         widget = QtWidgets.QDoubleSpinBox()
+        widget.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
         widget.setToolTip(tooltip)
         widget.setValue(value)
-        widget.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
         scaling_factor_widgets[name] = (label, widget)
 
     return scaling_factor_widgets
@@ -84,36 +84,36 @@ def _create_threshold_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     """Create widgets for setting thresholds for the HypothesisModel"""
 
     distance_threshold = QtWidgets.QDoubleSpinBox()
+    distance_threshold.setStepType(
+        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+    )
     distance_threshold.setToolTip(
         "A threshold distance from the edge of the field of view to add an "
         "initialization or termination hypothesis."
     )
     distance_threshold.setValue(20.0)
-    distance_threshold.setStepType(
-        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-    )
     widgets = {"theta_dist": ("distance threshold", distance_threshold)}
 
     time_threshold = QtWidgets.QDoubleSpinBox()
+    time_threshold.setStepType(
+        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+    )
     time_threshold.setToolTip(
         "A threshold time from the beginning or end of movie to add "
         "an initialization or termination hypothesis."
     )
     time_threshold.setValue(5.0)
-    time_threshold.setStepType(
-        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-    )
     widgets["theta_time"] = ("time threshold", time_threshold)
 
     apoptosis_threshold = QtWidgets.QSpinBox()
+    apoptosis_threshold.setStepType(
+        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+    )
     apoptosis_threshold.setToolTip(
         "Number of apoptotic detections to be considered a genuine event.\n"
         "Detections are counted consecutively from the back of the track"
     )
     apoptosis_threshold.setValue(5)
-    apoptosis_threshold.setStepType(
-        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-    )
     widgets["apop_thresh"] = ("apoptosis threshold", apoptosis_threshold)
 
     return widgets
@@ -123,25 +123,25 @@ def _create_bin_size_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     """Create widget for setting bin sizes for the HypothesisModel"""
 
     distance_bin_size = QtWidgets.QDoubleSpinBox()
+    distance_bin_size.setStepType(
+        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+    )
     distance_bin_size.setToolTip(
         "Isotropic spatial bin size for considering hypotheses.\n"
         "Larger bin sizes generate more hypothesese for each tracklet."
     )
     distance_bin_size.setValue(40.0)
-    distance_bin_size.setStepType(
-        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-    )
     widgets = {"dist_thresh": ("distance bin size", distance_bin_size)}
 
     time_bin_size = QtWidgets.QDoubleSpinBox()
+    time_bin_size.setStepType(
+        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+    )
     time_bin_size.setToolTip(
         "Temporal bin size for considering hypotheses.\n"
         "Larger bin sizes generate more hypothesese for each tracklet."
     )
     time_bin_size.setValue(2.0)
-    time_bin_size.setStepType(
-        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-    )
     widgets["time_thresh"] = ("time bin size", time_bin_size)
 
     return widgets
@@ -160,14 +160,14 @@ def create_hypothesis_model_widgets() -> (
     }
 
     segmentation_miss_rate = QtWidgets.QDoubleSpinBox()
+    segmentation_miss_rate.setStepType(
+        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+    )
     segmentation_miss_rate.setToolTip(
         "Miss rate for the segmentation.\n"
         "e.g. 1/100 segmentations incorrect gives a segmentation miss rate of 0.01."
     )
     segmentation_miss_rate.setValue(0.1)
-    segmentation_miss_rate.setStepType(
-        QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-    )
     widgets["segmentation_miss_rate"] = ("miss rate", segmentation_miss_rate)
 
     relax = QtWidgets.QCheckBox()

--- a/btrack/napari/widgets/_motion.py
+++ b/btrack/napari/widgets/_motion.py
@@ -7,31 +7,31 @@ def _create_sigma_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     """Create widgets for setting the magnitudes of the MotionModel matrices"""
 
     P_sigma = QtWidgets.QDoubleSpinBox()
+    P_sigma.setMaximum(250)
+    P_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     P_sigma.setToolTip(
         "Magnitude of error in initial estimates.\n"
         "Used to scale the matrix P."
     )
-    P_sigma.setMaximum(250)
     P_sigma.setValue(150.0)
-    P_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     widgets = {"P_sigma": ("max(<b>P</b>)", P_sigma)}
 
     G_sigma = QtWidgets.QDoubleSpinBox()
+    G_sigma.setMaximum(250)
+    G_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     G_sigma.setToolTip(
         "Magnitude of error in process.\n Used to scale the matrix G."
     )
-    G_sigma.setMaximum(250)
     G_sigma.setValue(15.0)
-    G_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     widgets["G_sigma"] = ("max(<b>G</b>)", G_sigma)
 
     R_sigma = QtWidgets.QDoubleSpinBox()
+    R_sigma.setMaximum(250)
+    R_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     R_sigma.setToolTip(
         "Magnitude of error in measurements.\n Used to scale the matrix R."
     )
-    R_sigma.setMaximum(250)
     R_sigma.setValue(5.0)
-    R_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     widgets["R_sigma"] = ("max(<b>R</b>)", R_sigma)
 
     return widgets
@@ -43,9 +43,9 @@ def create_motion_model_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     widgets = _create_sigma_widgets()
 
     accuracy = QtWidgets.QDoubleSpinBox()
+    accuracy.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     accuracy.setToolTip("Integration limits for calculating probabilities")
     accuracy.setValue(7.5)
-    accuracy.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     widgets["accuracy"] = ("accuracy", accuracy)
 
     return widgets

--- a/btrack/napari/widgets/_motion.py
+++ b/btrack/napari/widgets/_motion.py
@@ -7,7 +7,7 @@ def _create_sigma_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     """Create widgets for setting the magnitudes of the MotionModel matrices"""
 
     P_sigma = QtWidgets.QDoubleSpinBox()
-    P_sigma.setMaximum(250)
+    P_sigma.setRange(0, 500)
     P_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     P_sigma.setToolTip(
         "Magnitude of error in initial estimates.\n"
@@ -17,7 +17,7 @@ def _create_sigma_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     widgets = {"P_sigma": ("max(<b>P</b>)", P_sigma)}
 
     G_sigma = QtWidgets.QDoubleSpinBox()
-    G_sigma.setMaximum(250)
+    G_sigma.setRange(0, 500)
     G_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     G_sigma.setToolTip(
         "Magnitude of error in process.\n Used to scale the matrix G."
@@ -26,7 +26,7 @@ def _create_sigma_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     widgets["G_sigma"] = ("max(<b>G</b>)", G_sigma)
 
     R_sigma = QtWidgets.QDoubleSpinBox()
-    R_sigma.setMaximum(250)
+    R_sigma.setRange(0, 500)
     R_sigma.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     R_sigma.setToolTip(
         "Magnitude of error in measurements.\n Used to scale the matrix R."
@@ -43,6 +43,7 @@ def create_motion_model_widgets() -> dict[str, tuple[str, QtWidgets.QWidget]]:
     widgets = _create_sigma_widgets()
 
     accuracy = QtWidgets.QDoubleSpinBox()
+    accuracy.setRange(0.1, 10)
     accuracy.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
     accuracy.setToolTip("Integration limits for calculating probabilities")
     accuracy.setValue(7.5)


### PR DESCRIPTION
Fixes #366. Have adjusted to recommended values. For consistency, using `.setRange` throughout, which is a one-liner for `.setMinimum` & `.setMaximum`.

I also really like things being in alphabetical order, so have enforced that...