### PR TITLE
[WIP] Stop duplicate names

### DIFF
--- a/btrack/napari/main.py
+++ b/btrack/napari/main.py
@@ -375,5 +375,15 @@ def load_config_from_json(
         return
 
     config_name = configs.add_config(filename=load_path, overwrite=False)
+    existing_names = [
+        btrack_widget.config_name.itemText(i)
+        for i in range(btrack_widget.config_name.count())
+    ]
+    if config_name in existing_names:
+        _msg = (
+            "The `config name` matches one already present in the current "
+            f"napari window, i.e. {', '.join(existing_names)}"
+        )
+        raise AttributeError(_msg)
     btrack_widget.config_name.addItem(config_name)
     btrack_widget.config_name.setCurrentText(config_name)


### PR DESCRIPTION
I'm running into issues with the "Default" name. I think we need two tests:
- `test_load_config` which would load a valid config name, i.e. not one of `cell` or `particle`
- `test_load_config_duplicate_config` which would raise an error when attempting to load an existing config name, i.e. `cell` or `particle`

I haven't got this working, and we've run out of time