### PR TITLE
Correct passing of arguments `optimize`->`optimize`

### DIFF
--- a/btrack/core.py
+++ b/btrack/core.py
@@ -508,7 +508,7 @@ class BayesianTracker:
 
     def optimize(self, **kwargs):
         """Proxy for `optimise` for our American friends ;)"""
-        return self.optimise(**kwargs)
+        return self.optimise(options=kwargs)
 
     def optimise(self, options: Optional[dict] = None) -> list[hypothesis.Hypothesis]:
         """Optimize the tracks.


### PR DESCRIPTION
As an American friend I've been using `optimize` and just ran into a bug when I tried to pass an option.


`optimise` expects a dict, not many kwargs